### PR TITLE
Fix malformed 0007-pcie-gen2 hunk line counts

### DIFF
--- a/driver/patches/0007-pcie-gen2.patch
+++ b/driver/patches/0007-pcie-gen2.patch
@@ -1,6 +1,6 @@
 --- a/src/nvidia/src/kernel/gpu/gsp/kernel_gsp.c
 +++ b/src/nvidia/src/kernel/gpu/gsp/kernel_gsp.c
-@@ -4942,6 +4942,323 @@
+@@ -4942,6 +4942,260 @@
                        devId);
          }
  
@@ -263,7 +263,7 @@
          {
 --- a/src/nvidia/src/kernel/gpu/gsp/arch/turing/kernel_gsp_tu102.c
 +++ b/src/nvidia/src/kernel/gpu/gsp/arch/turing/kernel_gsp_tu102.c
-@@ -611,6 +611,50 @@
+@@ -611,6 +611,44 @@
          }
      }
  


### PR DESCRIPTION
AI Disclosure: Claude wrote this patch for me. 

The unified-diff hunk headers overstate the added-line counts, so GNU patch (used by driver/build.sh) reads past the end of the first hunk into the second file's `---` header and aborts with "malformed patch at line 264". A clean install.sh on a fresh open-gpu-kernel-modules tree then fails to apply 0007.

Correct both counts to the actual hunk-body lengths (no code lines change):
  kernel_gsp.c        @@ -4942,6 +4942,323 @@  ->  +4942,260
  kernel_gsp_tu102.c  @@  -611,6  +611,50 @@  ->   +611,44

Verified: 0001-0007 now apply cleanly to a fresh 610.43.03 tree with patch -p1.
