### PR TITLE
Add persistent PCIe Gen2 link retrain for CMP 170HX

### DIFF
--- a/common/99-cmpunlocker-pcie-gen2.rules
+++ b/common/99-cmpunlocker-pcie-gen2.rules
@@ -1,0 +1,9 @@
+# cmpunlocker — re-apply the PCIe Gen2 retrain whenever a driver (re)binds a
+# supported CMP card. A driver reload or GPU reset can drop the link back to
+# Gen1 without a PCI remove/add, so we trigger on the "bind" action and kick the
+# oneshot service (--no-block avoids blocking the udev worker; restart forces a
+# re-run even though the service is RemainAfterExit). The boot-time unit still
+# covers the normal cold start. See cmpunlocker-pcie-gen2.service.
+ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{device}=="0x20c2", RUN+="/usr/bin/systemctl --no-block restart cmpunlocker-pcie-gen2.service"
+ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{device}=="0x2082", RUN+="/usr/bin/systemctl --no-block restart cmpunlocker-pcie-gen2.service"
+ACTION=="bind", SUBSYSTEM=="pci", ATTR{vendor}=="0x10de", ATTR{device}=="0x20b0", RUN+="/usr/bin/systemctl --no-block restart cmpunlocker-pcie-gen2.service"

--- a/common/cmpunlocker-pcie-gen2.sh
+++ b/common/cmpunlocker-pcie-gen2.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# cmpunlocker — PCIe Gen2 link retrain for the CMP 170HX (and siblings).
+#
+# The card advertises PCIe Gen2 (5GT/s) in its Link Capabilities, but the link
+# trains at Gen1 (2.5GT/s) until a retrain is issued from the *upstream* root
+# port — setting the target speed on the endpoint alone does not drive the
+# negotiation. This writes the Gen2 target on both ends and sets the Retrain
+# Link bit on the root port. It lives in PCIe config space, so it resets on
+# reboot / link-down and must run on every boot (installed as a systemd unit).
+#
+# Width is not touched: the 170HX is electrically x4, so x4 is expected.
+set -uo pipefail
+
+VENDOR="10de"
+DEVICE_IDS=("20c2" "2082" "20b0")
+
+# PCIe capability register offsets, relative to the Express capability (CAP_EXP)
+LNKCTL="CAP_EXP+0x10.w"    # Link Control:  bit 5 = Retrain Link
+LNKSTA="CAP_EXP+0x12.w"    # Link Status:   bits 3:0 = Current Link Speed
+LNKCTL2="CAP_EXP+0x30.w"   # Link Control 2: bits 3:0 = Target Link Speed
+GEN2="0x2"                 # encoded link speed for 5GT/s
+
+log() { echo "cmpunlocker-pcie-gen2: $*"; }
+
+command -v setpci >/dev/null 2>&1 || { log "setpci not found (install pciutils)"; exit 1; }
+[[ "${EUID:-$(id -u)}" -eq 0 ]] || { log "must run as root"; exit 1; }
+
+# Current negotiated speed as a Gen number (1, 2, ...) for a device BDF.
+current_gen() {
+    local dev="$1" v
+    v="$(setpci -s "${dev}" "${LNKSTA}" 2>/dev/null || echo "")"
+    [[ -n "${v}" ]] || { echo "?"; return; }
+    echo $(( 0x${v} & 0xf ))
+}
+
+retrain_one() {
+    local gpu="$1" rp before after
+    rp="$(basename "$(dirname "$(readlink -f "/sys/bus/pci/devices/${gpu}")")")"
+    if [[ ! -e "/sys/bus/pci/devices/${rp}" || "${rp}" == "${gpu}" ]]; then
+        log "${gpu}: no upstream root port found, skipping"
+        return 1
+    fi
+
+    before="$(current_gen "${gpu}")"
+    if [[ "${before}" == "2" ]]; then
+        log "${gpu}: already at Gen2 (root port ${rp}), nothing to do"
+        return 0
+    fi
+
+    # Target Gen2 on both ends, then retrain from the root port.
+    setpci -s "${rp}"  "${LNKCTL2}=${GEN2}:0xf" 2>/dev/null || true
+    setpci -s "${gpu}" "${LNKCTL2}=${GEN2}:0xf" 2>/dev/null || true
+    setpci -s "${rp}"  "${LNKCTL}=0x20:0x20"    2>/dev/null || true
+    sleep 1
+
+    after="$(current_gen "${gpu}")"
+    if [[ "${after}" == "2" ]]; then
+        log "${gpu}: retrained Gen${before} -> Gen2 (root port ${rp})"
+        return 0
+    fi
+    log "${gpu}: retrain did not hold (Gen${before} -> Gen${after}); link may not sustain Gen2"
+    return 1
+}
+
+mapfile -t GPUS < <(
+    for id in "${DEVICE_IDS[@]}"; do
+        lspci -D -d "${VENDOR}:${id}" 2>/dev/null | awk '{print $1}'
+    done
+)
+
+if [[ ${#GPUS[@]} -eq 0 ]]; then
+    log "no supported CMP card found (${VENDOR}:${DEVICE_IDS[*]})"
+    exit 0
+fi
+
+rc=0
+for gpu in "${GPUS[@]}"; do
+    retrain_one "${gpu}" || rc=1
+done
+exit "${rc}"

--- a/driver/build.sh
+++ b/driver/build.sh
@@ -173,6 +173,21 @@ for ko in "${KO_FILES[@]}"; do
     ok "Installed ${base}"
 done
 
+# A stock DKMS build of the same driver in updates/dkms/ can outrank our patched
+# modules in the shared "updates" search path, so modprobe loads the unpatched
+# copy. Force depmod to always prefer updates/cmpunlocker for the nvidia modules.
+DEPMOD_OVERRIDE="/etc/depmod.d/zz-cmpunlocker.conf"
+if [[ -d /etc/depmod.d ]]; then
+    {
+        for mod in nvidia nvidia-modeset nvidia-uvm nvidia-drm nvidia-peermem; do
+            printf 'override %-15s * updates/cmpunlocker\n' "${mod}"
+        done
+    } > "${DEPMOD_OVERRIDE}"
+    ok "Wrote depmod override ${DEPMOD_OVERRIDE}"
+else
+    warn "/etc/depmod.d missing — cannot pin patched modules ahead of DKMS"
+fi
+
 depmod -a "${KVER}"
 ok "depmod complete"
 

--- a/install.sh
+++ b/install.sh
@@ -181,12 +181,63 @@ ok "NVIDIA driver ${detected} is supported"
 [[ -d "/lib/modules/$(uname -r)/build" ]] || die "Kernel headers missing for $(uname -r). Install linux-headers-$(uname -r) or kernel-devel."
 ok "Kernel headers present for $(uname -r)"
 
-step "Step 5/6: Building and installing patched modules"
+step "Step 5/7: Building and installing patched modules"
 chmod +x "${SCRIPT_DIR}/driver/build.sh"
 CMPUNLOCKER_DRIVER_VERSION="${detected}" CMPUNLOCKER_CARD_PROFILE="${CARD_PROFILE}" "${SCRIPT_DIR}/driver/build.sh"
 ok "Patched modules installed (profile ${CARD_PROFILE})"
 
-step "Step 6/6: Done"
+step "Step 6/7: Installing PCIe Gen2 retrain service"
+# The 170HX advertises PCIe Gen2 but trains at Gen1 until the link is retrained
+# from the upstream root port. That lives in PCIe config space and resets every
+# boot, so install a systemd oneshot to reapply it. Independent of the in-driver
+# unlock; it only touches link speed.
+PCIE_SRC="${SCRIPT_DIR}/common/cmpunlocker-pcie-gen2.sh"
+PCIE_BIN="/usr/local/sbin/cmpunlocker-pcie-gen2"
+PCIE_SERVICE="/etc/systemd/system/cmpunlocker-pcie-gen2.service"
+PCIE_RULES_SRC="${SCRIPT_DIR}/common/99-cmpunlocker-pcie-gen2.rules"
+PCIE_RULES="/etc/udev/rules.d/99-cmpunlocker-pcie-gen2.rules"
+if ! command -v setpci &>/dev/null; then
+    warn "setpci not found (pciutils) — skipping PCIe Gen2 service; link stays at Gen1"
+elif [[ ! -r "${PCIE_SRC}" ]]; then
+    warn "Missing ${PCIE_SRC} — skipping PCIe Gen2 service"
+else
+    install -m 0755 "${PCIE_SRC}" "${PCIE_BIN}"
+    ok "Installed ${PCIE_BIN}"
+    cat > "${PCIE_SERVICE}" <<EOF
+[Unit]
+Description=cmpunlocker PCIe Gen2 link retrain for CMP 170HX
+Documentation=https://github.com/eejohnso/cmpunlocker
+After=multi-user.target
+Wants=multi-user.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=${PCIE_BIN}
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    ok "Wrote ${PCIE_SERVICE}"
+    systemctl daemon-reload
+    systemctl enable cmpunlocker-pcie-gen2.service >/dev/null 2>&1 || true
+    if systemctl start cmpunlocker-pcie-gen2.service; then
+        ok "PCIe Gen2 retrain applied now and enabled at boot"
+    else
+        warn "PCIe Gen2 service enabled for boot, but immediate run failed — check: journalctl -u cmpunlocker-pcie-gen2"
+    fi
+    # udev rule re-applies the retrain when the driver rebinds (reload / reset),
+    # which does not produce a PCI remove/add event the boot unit would catch.
+    if [[ -r "${PCIE_RULES_SRC}" ]]; then
+        install -m 0644 "${PCIE_RULES_SRC}" "${PCIE_RULES}"
+        udevadm control --reload-rules 2>/dev/null || true
+        ok "Installed udev rule ${PCIE_RULES}"
+    else
+        warn "Missing ${PCIE_RULES_SRC} — driver-rebind retrain not installed"
+    fi
+fi
+
+step "Step 7/7: Done"
 echo ""
 echo -e "${CYAN}╔════════════════════════════════════════╗${NC}"
 echo -e "${CYAN}║${NC}   ${GREEN}✓ cmpunlocker install finished${CYAN}       ║${NC}"
@@ -198,6 +249,7 @@ echo -e "  1. Cold reboot recommended: ${CYAN}sudo shutdown -h now${NC}  (then p
 echo -e "  2. Verify memory: ${CYAN}nvidia-smi${NC}  (expect ~${EXPECTED_MIB} MiB)"
 echo -e "  3. Verify unlock logs: ${CYAN}sudo dmesg | grep SEC2_DEBUG${NC}"
 echo -e "  4. Verify SM clocks: ${CYAN}nvidia-smi --query-gpu=clocks.max.sm --format=csv,noheader${NC}"
+echo -e "  5. Verify PCIe Gen2: ${CYAN}nvidia-smi --query-gpu=pcie.link.gen.current --format=csv,noheader${NC}  (expect 2)"
 echo ""
 echo "Log saved to: ${LOG_FILE}"
 echo ""

--- a/remove.sh
+++ b/remove.sh
@@ -34,6 +34,7 @@ echo ""
 if [[ "${1:-}" != "--yes" && "${1:-}" != "-y" ]]; then
     warn "This removes cmpunlocker patched kernel modules:"
     echo "  - Stops leftover cmpunlocker systemd service (if present)"
+    echo "  - Removes the cmpunlocker-pcie-gen2 retrain service + udev rule (card reverts to Gen1)"
     echo "  - Removes /lib/modules/*/updates/cmpunlocker/"
     echo "  - Removes /etc/depmod.d/zz-cmpunlocker.conf override"
     echo "  - Removes ${INSTALL_DIR} (legacy install dir, if present)"
@@ -72,6 +73,27 @@ if [[ -f "${SERVICE_FILE}" ]]; then
     ok "Removed ${SERVICE_FILE}"
 fi
 pkill -f "${INSTALL_DIR}/daemon/watchdog.py" 2>/dev/null || true
+
+PCIE_SERVICE_NAME="cmpunlocker-pcie-gen2"
+PCIE_SERVICE_FILE="/etc/systemd/system/${PCIE_SERVICE_NAME}.service"
+PCIE_BIN="/usr/local/sbin/cmpunlocker-pcie-gen2"
+if systemctl is-enabled --quiet "${PCIE_SERVICE_NAME}" 2>/dev/null; then
+    systemctl disable "${PCIE_SERVICE_NAME}" 2>/dev/null || true
+fi
+systemctl stop "${PCIE_SERVICE_NAME}" 2>/dev/null || true
+if [[ -f "${PCIE_SERVICE_FILE}" ]]; then
+    rm -f "${PCIE_SERVICE_FILE}"
+    systemctl daemon-reload
+    systemctl reset-failed "${PCIE_SERVICE_NAME}" 2>/dev/null || true
+    ok "Removed ${PCIE_SERVICE_FILE}"
+fi
+[[ -f "${PCIE_BIN}" ]] && { rm -f "${PCIE_BIN}"; ok "Removed ${PCIE_BIN}"; }
+PCIE_RULES="/etc/udev/rules.d/99-cmpunlocker-pcie-gen2.rules"
+if [[ -f "${PCIE_RULES}" ]]; then
+    rm -f "${PCIE_RULES}"
+    udevadm control --reload-rules 2>/dev/null || true
+    ok "Removed ${PCIE_RULES}"
+fi
 
 step "Step 3/5: Removing patched modules and legacy files"
 DEPMOD_OVERRIDE="/etc/depmod.d/zz-cmpunlocker.conf"

--- a/remove.sh
+++ b/remove.sh
@@ -35,6 +35,7 @@ if [[ "${1:-}" != "--yes" && "${1:-}" != "-y" ]]; then
     warn "This removes cmpunlocker patched kernel modules:"
     echo "  - Stops leftover cmpunlocker systemd service (if present)"
     echo "  - Removes /lib/modules/*/updates/cmpunlocker/"
+    echo "  - Removes /etc/depmod.d/zz-cmpunlocker.conf override"
     echo "  - Removes ${INSTALL_DIR} (legacy install dir, if present)"
     echo "  - Reloads stock NVIDIA modules (brief display interruption)"
     echo ""
@@ -73,6 +74,14 @@ fi
 pkill -f "${INSTALL_DIR}/daemon/watchdog.py" 2>/dev/null || true
 
 step "Step 3/5: Removing patched modules and legacy files"
+DEPMOD_OVERRIDE="/etc/depmod.d/zz-cmpunlocker.conf"
+override_removed=0
+if [[ -f "${DEPMOD_OVERRIDE}" ]]; then
+    rm -f "${DEPMOD_OVERRIDE}"
+    override_removed=1
+    ok "Removed depmod override ${DEPMOD_OVERRIDE}"
+fi
+
 mod_removed=0
 kernels_touched=()
 shopt -s nullglob
@@ -87,6 +96,13 @@ for mod_dir in /lib/modules/*/updates/cmpunlocker; do
     fi
 done
 [[ "${mod_removed}" -gt 0 ]] || warn "No patched kernel modules found"
+
+# If we dropped the override but touched no module dirs, modules.dep still
+# reflects the stale override — regenerate it once for the running kernel.
+if [[ "${override_removed}" -eq 1 && ${#kernels_touched[@]} -eq 0 ]]; then
+    depmod -a "$(uname -r)" 2>/dev/null || true
+    ok "Refreshed depmod after override removal"
+fi
 
 if [[ ${#kernels_touched[@]} -gt 0 ]]; then
     info "Rebuilding initramfs so stock modules are packed again..."


### PR DESCRIPTION
## Summary
Adds a persistent PCIe **Gen2** link retrain for the CMP 170HX. The card advertises Gen2 (5GT/s) in its Link Capabilities but the link trains at Gen1 until a retrain is driven from the **upstream root port** — setting the target speed on the endpoint alone doesn't drive the negotiation. This packages that retrain so it survives reboots and driver reloads.

## Changes
- **`common/cmpunlocker-pcie-gen2.sh`** → installed to `/usr/local/sbin/`: for each supported card, resolves the upstream root port, sets the Gen2 target on both ends, and sets the Retrain Link bit on the root port. Skips cards already at Gen2 and logs any retrain that doesn't hold. Width is left untouched (170HX is electrically x4, so x4 is expected).
- **`cmpunlocker-pcie-gen2.service`** — a `Type=oneshot` unit, enabled at boot and applied immediately during install (PCIe link speed lives in config space and resets on reboot/link-down).
- **`common/99-cmpunlocker-pcie-gen2.rules`** — udev `bind` trigger that re-fires the retrain on driver reload / GPU reset, which produce no PCI add event the boot unit would catch.
- **`install.sh`** — installs all of the above (guarded on `setpci` availability), plus a `nvidia-smi ... pcie.link.gen.current` verification hint.
- **`remove.sh`** — tears down the service, binary, and udev rule.

> Note: this branch also contains a separate first commit ("Pin patched modules ahead of DKMS via depmod override") that was pending in the tree — it's isolated as its own commit for easy review or drop.

## Testing
- **Live hardware:** the core sequence — Gen2 target on both ends + Retrain Link bit **on the root port** — was verified on a live CMP 170HX. `LnkSta` moved from `Speed 2.5GT/s (downgraded)` to **5GT/s** and held; `LnkCap` was `5GT/s` / x16 and the target was already 5GT/s, confirming the endpoint-only retrain was the missing piece.
- **Not yet run end-to-end:** the packaged `install.sh` service + udev automation has not been exercised on hardware yet. Scripts pass `bash -n`; the retrain script filters to `10de:20c2/2082/20b0` and no-ops on other cards.

**Hardware tested on (if applicable):**
- GPU variant: CMP 170HX (GA100, `10de:20c2`)
- PCIe slot / host: physical x16 slot, no riser (card is electrically x4)
- Kernel / OS: Linux 6.17.0-41-generic

🤖 Generated with [Claude Code](https://claude.com/claude-code)
