### PR TITLE
Add early Gen2 retraining validated on 10GB CMP 170HX

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,26 @@ See [the 10 GB `10de:2082` validation](docs/gen2-10gb-2082-validation.md) for
 the tested hardware/software configuration, boot timing, bandwidth results,
 and reporting differences from the published 8 GB result.
 
+#### Verified 10 GB (`10de:2082`) result
+
+The early service has been validated on one 10 GB card with driver
+`610.43.02`, VBIOS `92.00.66.00.02`, and an Intel Xeon E5 v4 host:
+
+| Measurement | Gen1 x4 | Gen2 x4 |
+|---|---:|---:|
+| PCI configuration `LnkSta` | `0x1041` | `0x1042` |
+| sysfs `current_link_speed` | 2.5 GT/s | 5.0 GT/s |
+| Pinned H2D bandwidth | ~0.82 GB/s | 1.633 GB/s |
+| Pinned D2H bandwidth | ~0.84 GB/s | 1.679 GB/s |
+| Unlocked memory | 40960 MiB | 40960 MiB |
+
+On this 10 GB configuration, NVML/`nvidia-smi` continued to report PCIe Gen1
+and sysfs `max_link_speed` returned to 2.5 GT/s after the transient window
+closed. Those fields were stale capability reports: `LnkSta=0x1042`, sysfs
+`current_link_speed=5.0 GT/s`, and the doubled host-transfer bandwidth
+confirmed that the link remained negotiated at Gen2. Do not use
+`nvidia-smi` as the only Gen2 success criterion on `10de:2082`.
+
 ### IOMMU
 
 The installer also enables the IOMMU in passthrough mode, appending `intel_iommu=on iommu=pt` (Intel) or `amd_iommu=on iommu=pt` (AMD) to the kernel command line via `/etc/default/grub` or `/etc/kernel/cmdline`, then regenerating the boot config. Conflicting `iommu=` / `*_iommu=` entries are replaced, the original file is backed up to `*.cmpunlocker.bak`, and `remove.sh` restores it.
@@ -115,8 +135,8 @@ nvidia-smi
 # 10GB card: expect ~40960 MiB
 
 nvidia-smi --query-gpu=memory.total,pcie.link.gen.current,pcie.link.gen.max,clocks.max.sm --format=csv
-# Expect pcie.link.gen.current=2. The advertised max may return to 1 after the
-# transient bootstrap window closes; current negotiated speed is authoritative.
+# The 8GB variant may report current=2. On the tested 10GB/2082 card, NVML
+# continued to report current=1/max=1 after a successful Gen2 retrain.
 
 sudo lspci -d 10de:20c2 -vv | grep -E 'LnkCap:|LnkSta:'  # 8GB
 sudo lspci -d 10de:2082 -vv | grep -E 'LnkCap:|LnkSta:'  # 10GB

--- a/README.md
+++ b/README.md
@@ -63,6 +63,36 @@ sudo ./install.sh --profile=8gb    # 8GB card → 64GB unlock
 sudo ./install.sh --profile=10gb   # 10GB card → 40GB unlock
 ```
 
+### Early-boot PCIe Gen2 retraining
+
+The Gen2 capability opened by `0007-pcie-gen2.patch` is transient during GSP
+bootstrap. The installer therefore enables `cmp-gen2-early.service`, which asks
+the CMP endpoint and its dynamically detected upstream bridge for Gen2 every
+50 ms during early boot. It stops as soon as the negotiated `LnkSta` reaches
+Gen2. The installer only enables the service; it never retrains the active link
+in the current desktop session.
+
+To install the memory/compute patches without arming early PCIe retraining:
+
+```bash
+sudo ./install.sh --no-gen2-service
+```
+
+The standalone service controls leave the patched NVIDIA driver untouched:
+
+```bash
+sudo ./tools/cmp-gen2-service.sh install
+sudo ./tools/cmp-gen2-service.sh verify
+sudo ./tools/cmp-gen2-service.sh remove
+```
+
+If a machine does not finish booting during first-time testing, add
+`systemd.mask=cmp-gen2-early.service` temporarily to the kernel command line.
+
+See [the 10 GB `10de:2082` validation](docs/gen2-10gb-2082-validation.md) for
+the tested hardware/software configuration, boot timing, bandwidth results,
+and reporting differences from the published 8 GB result.
+
 ### IOMMU
 
 The installer also enables the IOMMU in passthrough mode, appending `intel_iommu=on iommu=pt` (Intel) or `amd_iommu=on iommu=pt` (AMD) to the kernel command line via `/etc/default/grub` or `/etc/kernel/cmdline`, then regenerating the boot config. Conflicting `iommu=` / `*_iommu=` entries are replaced, the original file is backed up to `*.cmpunlocker.bak`, and `remove.sh` restores it.
@@ -85,11 +115,14 @@ nvidia-smi
 # 10GB card: expect ~40960 MiB
 
 nvidia-smi --query-gpu=memory.total,pcie.link.gen.current,pcie.link.gen.max,clocks.max.sm --format=csv
-# Expect pcie.link.gen.current=2 and pcie.link.gen.max=2 after reboot
+# Expect pcie.link.gen.current=2. The advertised max may return to 1 after the
+# transient bootstrap window closes; current negotiated speed is authoritative.
 
-sudo lspci -d 10de:20c2 -vv | grep -E 'LnkCap:|LnkSta:'
+sudo lspci -d 10de:20c2 -vv | grep -E 'LnkCap:|LnkSta:'  # 8GB
+sudo lspci -d 10de:2082 -vv | grep -E 'LnkCap:|LnkSta:'  # 10GB
 # Expect LnkSta: Speed 5GT/s (not 2.5GT/s)
 
+sudo ./tools/cmp-gen2-service.sh verify
 sudo dmesg | grep SEC2_DEBUG
 # Expected: PLMs opening to 0xffffffff, CFG1/LMR/SS0/SS1 writes, late PMA
 cat /lib/modules/$(uname -r)/updates/cmpunlocker/card_profile
@@ -102,7 +135,7 @@ cat /lib/modules/$(uname -r)/updates/cmpunlocker/card_profile
 |---|---|
 | Full SM compute throughput (SS0/SS1) | Working ✓ |
 | Memory geometry (64GB on 8GB cards, 40GB on 10GB cards) | Working ✓ |
-| PCIe Gen2 link (`5GT/s`, Device Max ≥ 2) | Working ✓ |
+| PCIe Gen2 link (`LnkSta` at `5GT/s`) | Early-boot retrain required |
 | Persistence across reboot (patched modules) | Working ✓ |
 
 ---

--- a/docs/gen2-10gb-2082-validation.md
+++ b/docs/gen2-10gb-2082-validation.md
@@ -1,0 +1,123 @@
+# PCIe Gen2 validation on the 10 GB CMP 170HX (`10de:2082`)
+
+This documents one successful 10 GB validation of the transient-window Gen2
+retrain. It is a single-system result, not a claim that every `2082` board or
+host platform will behave identically.
+
+The early-retrain mechanism is based on
+[`studebaker8/cmp170hx-gen2`](https://github.com/studebaker8/cmp170hx-gen2):
+patch `0007` transiently exposes Gen2 capability during GSP bootstrap, and a
+userspace service repeatedly initiates retraining from the upstream bridge
+while that window is open.
+
+## Test configuration
+
+| Component | Configuration |
+|---|---|
+| GPU | CMP 170HX 10 GB, `10de:2082`, revision A1 |
+| GPU BDF | `0000:02:00.0` |
+| VBIOS | `92.00.66.00.02` |
+| Driver | NVIDIA open kernel module `610.43.02` |
+| Unlocked memory | `40960 MiB` |
+| Maximum SM clock | `1410 MHz` |
+| OS | Ubuntu 26.04 LTS |
+| Kernel | `7.0.0-28-generic` |
+| CPU | Intel Xeon E5-2690 v4 |
+| Mainboard | Supermicro X10DRG-Q, BIOS 3.2 |
+| Upstream port | `0000:00:03.0`, Intel `8086:6f08` |
+| Upstream capability | 8.0 GT/s, x16 maximum |
+| Physical GPU link width | x4 |
+
+The successful boot had `intel_iommu=on iommu=pt` enabled, but the retrain
+helper does not use the IOMMU and this result should not be interpreted as
+evidence that IOMMU is required.
+
+## Boot timing and result
+
+On the validated cold boot:
+
+| Event | Monotonic boot time |
+|---|---:|
+| `sysinit.target` reached | 3.961 s |
+| Early retrain helper started | 7.662 s |
+| Driver logged transient `CAP2=0x06` | 7.804 s |
+| Gen2 trained on iteration 4 | 7.918 s |
+
+The successful service record was:
+
+```text
+0000:02:00.0: SUCCESS Gen2 at iteration 4;
+LnkSta=0x1042; LnkCap2=0x00000006
+```
+
+Negotiated-link and functional results:
+
+| Measurement | Before | After |
+|---|---:|---:|
+| `LnkSta` | `0x1041` | `0x1042` |
+| sysfs `current_link_speed` | 2.5 GT/s | 5.0 GT/s |
+| Link width | x4 | x4 |
+| Pinned H2D bandwidth | approximately 0.82 GB/s | 1.633 GB/s |
+| Pinned D2H bandwidth | approximately 0.84 GB/s | 1.679 GB/s |
+| Unlocked memory | 40960 MiB | 40960 MiB |
+| Maximum SM clock | 1410 MHz | 1410 MHz |
+
+The post-change bandwidth test used a 512 MiB pinned PyTorch tensor, two warmup
+copies, and eight measured copies in each direction. No PCIe AER errors,
+NVIDIA Xids, or fallen-off-bus messages were observed.
+
+## Differences from the published 8 GB result
+
+The original public validation used the 8 GB `10de:20c2` variant, unlocked to
+64 GB, on an AMD B650M host. This validation used the 10 GB `10de:2082`
+variant, unlocked to 40 GB, on an Intel Xeon platform.
+
+There are two important reporting differences on this 10 GB configuration:
+
+1. After the transient capability window closed, sysfs reported
+   `max_link_speed=2.5 GT/s` while the negotiated
+   `current_link_speed=5.0 GT/s`. The negotiated speed and transfer bandwidth,
+   not the post-window maximum capability, are authoritative.
+2. NVIDIA NVML reported `pcie.link.gen.current=1` and
+   `pcie.link.gen.max=1` even though PCI configuration `LnkSta=0x1042`, sysfs
+   reported 5.0 GT/s, and host transfer bandwidth doubled. Do not use NVML as
+   the only success criterion on this configuration.
+
+The existing `0008-pcie-gen2-probe-retrain.patch` also printed:
+
+```text
+CMP Gen2: PCIe retrain completed without Gen2 link
+(status=0x1042, ret=0)
+```
+
+`0x1042` already encodes Gen2 in the low four bits. The false failure occurred
+because the check additionally required `PCI_EXP_LNKSTA_DLLLA`, an optional
+status bit that was not set on this endpoint. The accompanying patch removes
+that extra requirement.
+
+## Operation and rollback
+
+The installer enables `cmp-gen2-early.service` but does not start it in the
+running desktop session. The service dynamically discovers each supported CMP
+GPU and its immediate upstream PCI bridge, validates vendor/device/class
+identifiers, and stops after Gen2 is negotiated or after a bounded 30-second
+attempt window.
+
+Verify:
+
+```bash
+sudo ./tools/cmp-gen2-service.sh verify
+```
+
+Remove only the early retrain service while keeping the patched driver and
+memory unlock:
+
+```bash
+sudo ./tools/cmp-gen2-service.sh remove
+```
+
+For first-boot recovery, add this temporary kernel parameter:
+
+```text
+systemd.mask=cmp-gen2-early.service
+```

--- a/driver/patches/0008-pcie-gen2-probe-retrain.patch
+++ b/driver/patches/0008-pcie-gen2-probe-retrain.patch
@@ -80,7 +80,7 @@
 +    {
 +        msleep(100);
 +        ret = pcie_capability_read_word(gpu, PCI_EXP_LNKSTA, &link_status);
-+        if (!ret && (link_status & PCI_EXP_LNKSTA_DLLLA) &&
++        if (!ret &&
 +            ((link_status & PCI_EXP_LNKSTA_CLS) >= PCI_EXP_LNKSTA_CLS_5_0GB))
 +        {
 +            NV_DEV_PRINTF(NV_DBG_INFO, nv, "CMP Gen2: PCIe link trained to Gen%u\n",

--- a/install.sh
+++ b/install.sh
@@ -10,18 +10,22 @@ LOG_FILE="${LOG_DIR}/install_$(date +%Y%m%d_%H%M%S).log"
 
 PROFILE_OVERRIDE=""
 CONFIGURE_IOMMU=1
+CONFIGURE_GEN2_SERVICE=1
 for arg in "$@"; do
     case "${arg}" in
         --profile=8gb|--profile=8GB) PROFILE_OVERRIDE="8gb" ;;
         --profile=10gb|--profile=10GB) PROFILE_OVERRIDE="10gb" ;;
         --no-iommu) CONFIGURE_IOMMU=0 ;;
+        --no-gen2-service) CONFIGURE_GEN2_SERVICE=0 ;;
         -h|--help)
             cat <<'EOF'
-Usage: sudo ./install.sh [--profile=8gb|10gb] [--no-iommu]
+Usage: sudo ./install.sh [--profile=8gb|10gb] [--no-iommu] [--no-gen2-service]
 
   --profile=8gb   Force 8GB metadata label (geometry is still chosen per PCI ID)
   --profile=10gb  Force 10GB metadata label (geometry is still chosen per PCI ID)
   --no-iommu      Do not touch the kernel command line (leave IOMMU settings alone)
+  --no-gen2-service
+                  Do not install the early-boot PCIe Gen2 retrain service
 
 By default the installer appends intel_iommu=on / amd_iommu=on plus iommu=pt to
 the kernel command line so the IOMMU runs in passthrough mode. This takes effect
@@ -292,6 +296,15 @@ rm -f /etc/systemd/system/cmpretrain.service \
 systemctl daemon-reload
 ok "Removed legacy PCIe retrain helpers"
 
+if (( CONFIGURE_GEN2_SERVICE == 1 )); then
+    chmod +x "${SCRIPT_DIR}/tools/cmp-gen2-hammer.sh" \
+             "${SCRIPT_DIR}/tools/cmp-gen2-service.sh"
+    "${SCRIPT_DIR}/tools/cmp-gen2-service.sh" install
+    ok "Early-boot Gen2 retrain service armed (not started in this session)"
+else
+    warn "--no-gen2-service given; early-boot PCIe retraining is not installed"
+fi
+
 step "Step 5c/6: Configuring IOMMU (passthrough)"
 IOMMU_STATUS="skipped"
 IOMMU_PARAMS=""
@@ -447,10 +460,14 @@ echo ""
 echo "Next:"
 echo -e "  1. Cold reboot recommended: ${CYAN}sudo shutdown -h now${NC}  (then power on)"
 echo -e "  2. Verify all GPUs: ${CYAN}sudo ./verify.sh${NC}"
-echo -e "  3. Verify PCIe Gen2: ${CYAN}nvidia-smi --query-gpu=pcie.link.gen.current,pcie.link.gen.max --format=csv${NC}  (expect 2,2)"
+echo -e "  3. Verify PCIe Gen2: ${CYAN}nvidia-smi --query-gpu=pcie.link.gen.current,pcie.link.gen.max --format=csv${NC}  (current must be 2; max may return to 1)"
 echo -e "  4. Or check manually: ${CYAN}nvidia-smi${NC}"
 echo -e "  5. Unlock logs: ${CYAN}sudo dmesg | grep SEC2_DEBUG${NC}"
 echo -e "  6. Verify IOMMU after reboot: ${CYAN}cat /proc/cmdline${NC} and ${CYAN}ls /sys/class/iommu${NC}"
+if (( CONFIGURE_GEN2_SERVICE == 1 )); then
+    echo -e "  7. Verify negotiated Gen2: ${CYAN}sudo ./tools/cmp-gen2-service.sh verify${NC}"
+    echo -e "     Recovery boot option: ${CYAN}systemd.mask=cmp-gen2-early.service${NC}"
+fi
 echo ""
 echo "Log saved to: ${LOG_FILE}"
 echo ""

--- a/remove.sh
+++ b/remove.sh
@@ -37,7 +37,7 @@ if [[ "${1:-}" != "--yes" && "${1:-}" != "-y" ]]; then
     echo "  - Removes /lib/modules/*/updates/cmpunlocker/"
     echo "  - Removes ${INSTALL_DIR} (legacy install dir, if present)"
     echo "  - Reloads stock NVIDIA modules (brief display interruption)"
-    echo "  - Removes cmpretrain service / modprobe Gen2 helpers"
+    echo "  - Removes early/legacy PCIe Gen2 helpers"
     echo "  - Restores the pre-install kernel command line (reverts IOMMU changes)"
     echo ""
     echo "Run: sudo ./remove.sh --yes"
@@ -78,8 +78,11 @@ for legacy_unit in cmpretrain.service cmp-gen2-retrain.service; do
     systemctl disable --now "${legacy_unit}" 2>/dev/null || true
     systemctl reset-failed "${legacy_unit}" 2>/dev/null || true
 done
+systemctl disable --now cmp-gen2-early.service 2>/dev/null || true
+systemctl reset-failed cmp-gen2-early.service 2>/dev/null || true
 rm -f /etc/systemd/system/cmpretrain.service /usr/local/sbin/retrain.sh
 rm -f /etc/systemd/system/cmp-gen2-retrain.service /usr/local/sbin/cmp-gen2-retrain.sh
+rm -f /etc/systemd/system/cmp-gen2-early.service /usr/local/sbin/cmp-gen2-hammer
 rm -f /etc/modprobe.d/cmp-pcie-gen2.conf
 systemctl daemon-reload 2>/dev/null || true
 ok "Removed PCIe Gen2 helpers"

--- a/systemd/cmp-gen2-early.service
+++ b/systemd/cmp-gen2-early.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=CMP 170HX early PCIe Gen2 retrain
+Documentation=https://github.com/studebaker8/cmp170hx-gen2
+DefaultDependencies=no
+After=sysinit.target
+Before=basic.target multi-user.target graphical.target
+ConditionPathExists=/usr/local/sbin/cmp-gen2-hammer
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/cmp-gen2-hammer
+TimeoutStartSec=45
+RemainAfterExit=no
+
+[Install]
+WantedBy=sysinit.target

--- a/tools/cmp-gen2-hammer.sh
+++ b/tools/cmp-gen2-hammer.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Early-retrain mechanism adapted from studebaker8/cmp170hx-gen2 (MIT).
+# This implementation adds strict device/bridge guards and project integration.
+set -uo pipefail
+
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+readonly VENDOR_ID="10de"
+readonly LOG_FILE="/var/log/cmp-gen2-early.log"
+readonly TARGET_GEN="${CMP_GEN2_TARGET:-2}"
+readonly MAX_ITERATIONS="${CMP_GEN2_MAX_ITERATIONS:-600}"
+readonly RETRAIN_INTERVAL="${CMP_GEN2_RETRAIN_INTERVAL:-0.05}"
+
+log() {
+    local line
+    line="[$(date -Is)] $*"
+    echo "${line}"
+    echo "${line}" >> "${LOG_FILE}" 2>/dev/null || true
+}
+
+read_link_status() {
+    setpci -s "$1" CAP_EXP+12.w 2>/dev/null || true
+}
+
+link_generation() {
+    local status
+    status="$(read_link_status "$1")"
+    if [[ "${status}" =~ ^[[:xdigit:]]{4}$ ]]; then
+        echo $((0x${status} & 0x0f))
+    else
+        echo "?"
+    fi
+}
+
+is_supported_gpu() {
+    local bdf="$1"
+    local vendor device
+    [[ -r "/sys/bus/pci/devices/${bdf}/vendor" ]] || return 1
+    [[ -r "/sys/bus/pci/devices/${bdf}/device" ]] || return 1
+    vendor="$(<"/sys/bus/pci/devices/${bdf}/vendor")"
+    device="$(<"/sys/bus/pci/devices/${bdf}/device")"
+    [[ "${vendor,,}" == "0x${VENDOR_ID}" ]] || return 1
+    [[ "${device,,}" == "0x20c2" || "${device,,}" == "0x2082" ]]
+}
+
+upstream_bridge() {
+    local bdf="$1"
+    local parent
+    parent="$(basename "$(dirname "$(readlink -f "/sys/bus/pci/devices/${bdf}")")")"
+    [[ "${parent}" != "${bdf}" ]] || return 1
+    [[ -e "/sys/bus/pci/devices/${parent}" ]] || return 1
+    echo "${parent}"
+}
+
+is_pci_bridge() {
+    local bdf="$1"
+    local class
+    [[ -r "/sys/bus/pci/devices/${bdf}/class" ]] || return 1
+    class="$(<"/sys/bus/pci/devices/${bdf}/class")"
+    [[ "${class,,}" == 0x0604* ]]
+}
+
+retrain_one() {
+    local gpu="$1"
+    local bridge initial status generation cap2 iteration
+
+    if ! is_supported_gpu "${gpu}"; then
+        log "${gpu}: vendor/device guard failed; refusing to touch the device"
+        return 1
+    fi
+    bridge="$(upstream_bridge "${gpu}" || true)"
+    if [[ -z "${bridge}" ]] || ! is_pci_bridge "${bridge}"; then
+        log "${gpu}: no valid upstream PCI bridge found; skipping"
+        return 1
+    fi
+
+    initial="$(link_generation "${gpu}")"
+    if [[ "${initial}" =~ ^[0-9]+$ ]] && (( initial >= TARGET_GEN )); then
+        log "${gpu}: already Gen${initial}; no retrain needed"
+        return 0
+    fi
+
+    log "${gpu}: start via upstream ${bridge}; initial Gen${initial}; target Gen${TARGET_GEN}"
+    for ((iteration = 1; iteration <= MAX_ITERATIONS; iteration++)); do
+        if ! is_supported_gpu "${gpu}"; then
+            log "${gpu}: disappeared during retrain; stopping immediately"
+            return 1
+        fi
+
+        # Preserve all unrelated bits. The endpoint may clamp this request to
+        # Gen1 until patch 0007 briefly exposes Gen2 support during GSP boot.
+        setpci -s "${bridge}" CAP_EXP+30.w=0002:000f 2>/dev/null || true
+        setpci -s "${gpu}" CAP_EXP+30.w=0002:000f 2>/dev/null || true
+
+        # PCIe retraining must be initiated by the upstream bridge.
+        setpci -s "${bridge}" CAP_EXP+10.w=0020:0020 2>/dev/null || true
+
+        status="$(read_link_status "${gpu}")"
+        if [[ "${status}" =~ ^[[:xdigit:]]{4}$ ]]; then
+            generation=$((0x${status} & 0x0f))
+            if (( generation >= TARGET_GEN )); then
+                cap2="$(setpci -s "${gpu}" CAP_EXP+2c.l 2>/dev/null || echo unreadable)"
+                log "${gpu}: SUCCESS Gen${generation} at iteration ${iteration}; LnkSta=0x${status}; LnkCap2=0x${cap2}"
+                return 0
+            fi
+        fi
+        sleep "${RETRAIN_INTERVAL}"
+    done
+
+    generation="$(link_generation "${gpu}")"
+    log "${gpu}: no Gen2 window caught after ${MAX_ITERATIONS} attempts; final Gen${generation}"
+    return 1
+}
+
+main() {
+    local rc=0
+    local -a gpus=()
+
+    if [[ "${EUID}" -ne 0 ]]; then
+        echo "cmp-gen2-hammer must run as root" >&2
+        exit 1
+    fi
+    if [[ "${TARGET_GEN}" != "2" ]]; then
+        echo "Only Gen2 is supported by this safety-constrained helper" >&2
+        exit 1
+    fi
+    if ! [[ "${MAX_ITERATIONS}" =~ ^[1-9][0-9]*$ ]]; then
+        echo "CMP_GEN2_MAX_ITERATIONS must be a positive integer" >&2
+        exit 1
+    fi
+    command -v lspci >/dev/null || { echo "lspci is required" >&2; exit 1; }
+    command -v setpci >/dev/null || { echo "setpci is required" >&2; exit 1; }
+
+    : > "${LOG_FILE}"
+    log "early retrain started (attempts=${MAX_ITERATIONS}, interval=${RETRAIN_INTERVAL}s)"
+
+    mapfile -t gpus < <(
+        for id in 20c2 2082; do
+            lspci -D -d "${VENDOR_ID}:${id}" 2>/dev/null | awk '{print $1}'
+        done
+    )
+    if [[ ${#gpus[@]} -eq 0 ]]; then
+        log "no supported CMP 170HX found; nothing touched"
+        return 0
+    fi
+
+    for gpu in "${gpus[@]}"; do
+        retrain_one "${gpu}" || rc=1
+    done
+    log "early retrain finished (rc=${rc})"
+    return "${rc}"
+}
+
+main "$@"

--- a/tools/cmp-gen2-service.sh
+++ b/tools/cmp-gen2-service.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SERVICE_NAME="cmp-gen2-early.service"
+SERVICE_SOURCE="${PROJECT_DIR}/systemd/${SERVICE_NAME}"
+SERVICE_TARGET="/etc/systemd/system/${SERVICE_NAME}"
+HAMMER_SOURCE="${SCRIPT_DIR}/cmp-gen2-hammer.sh"
+HAMMER_TARGET="/usr/local/sbin/cmp-gen2-hammer"
+LOG_FILE="/var/log/cmp-gen2-early.log"
+
+info() { echo "==> $*"; }
+ok() { echo "✓ $*"; }
+warn() { echo "! $*" >&2; }
+die() { echo "✗ $*" >&2; exit 1; }
+
+usage() {
+    cat <<EOF
+Usage:
+  sudo ${0} install   Install and enable the early-boot Gen2 service
+  sudo ${0} remove    Disable and remove the service (driver remains installed)
+  sudo ${0} verify    Verify negotiated link speed and show the boot log
+  ${0} status         Show whether the service is installed and enabled
+
+The install action never starts the retrain loop in the running desktop session.
+It only arms the service for the next boot.
+EOF
+}
+
+require_root() {
+    [[ "${EUID}" -eq 0 ]] || die "Run this action as root"
+}
+
+supported_gpus() {
+    for id in 20c2 2082; do
+        lspci -D -d "10de:${id}" 2>/dev/null | awk '{print $1}'
+    done
+}
+
+link_generation() {
+    local status
+    status="$(setpci -s "$1" CAP_EXP+12.w 2>/dev/null || true)"
+    if [[ "${status}" =~ ^[[:xdigit:]]{4}$ ]]; then
+        echo $((0x${status} & 0x0f))
+    else
+        echo "?"
+    fi
+}
+
+install_service() {
+    local module="/lib/modules/$(uname -r)/updates/cmpunlocker/nvidia.ko"
+    local -a gpus=()
+
+    require_root
+    command -v install >/dev/null || die "install command not found"
+    command -v lspci >/dev/null || die "lspci not found (install pciutils)"
+    command -v setpci >/dev/null || die "setpci not found (install pciutils)"
+    [[ -f "${HAMMER_SOURCE}" ]] || die "Missing ${HAMMER_SOURCE}"
+    [[ -f "${SERVICE_SOURCE}" ]] || die "Missing ${SERVICE_SOURCE}"
+
+    mapfile -t gpus < <(supported_gpus)
+    [[ ${#gpus[@]} -gt 0 ]] || die "No supported CMP 170HX found (10de:20c2 / 10de:2082)"
+    info "Detected: ${gpus[*]}"
+
+    if [[ ! -f "${module}" ]]; then
+        die "Patched cmpunlocker module not found: ${module}"
+    fi
+    if ! grep -aFq 'SEC2_DEBUG: PCIe' "${module}" 2>/dev/null; then
+        die "Installed module does not contain patch 0007; refusing to arm a useless retrain service"
+    fi
+    ok "Installed NVIDIA module contains the transient Gen2-window patch"
+
+    install -m 0755 "${HAMMER_SOURCE}" "${HAMMER_TARGET}"
+    install -m 0644 "${SERVICE_SOURCE}" "${SERVICE_TARGET}"
+    systemctl daemon-reload
+    systemctl enable "${SERVICE_NAME}" >/dev/null
+    ok "Enabled ${SERVICE_NAME} for the next boot"
+    info "The service was not started now; the active desktop PCIe link was not touched."
+    info "Recovery boot option: systemd.mask=${SERVICE_NAME}"
+}
+
+remove_service() {
+    require_root
+    systemctl disable --now "${SERVICE_NAME}" 2>/dev/null || true
+    rm -f "${SERVICE_TARGET}" "${HAMMER_TARGET}"
+    systemctl daemon-reload
+    systemctl reset-failed "${SERVICE_NAME}" 2>/dev/null || true
+    ok "Removed ${SERVICE_NAME}; cmpunlocker driver and memory unlock were left intact"
+    if [[ -f "${LOG_FILE}" ]]; then
+        info "Preserved diagnostic log: ${LOG_FILE}"
+    fi
+}
+
+show_status() {
+    if [[ -f "${SERVICE_TARGET}" ]]; then
+        ok "Service file installed: ${SERVICE_TARGET}"
+    else
+        warn "Service file is not installed"
+    fi
+    systemctl is-enabled "${SERVICE_NAME}" 2>/dev/null || true
+    systemctl status "${SERVICE_NAME}" --no-pager 2>/dev/null || true
+}
+
+verify_links() {
+    local gpu bridge status generation speed width max_speed
+    local failures=0
+    local -a gpus=()
+
+    require_root
+    mapfile -t gpus < <(supported_gpus)
+    [[ ${#gpus[@]} -gt 0 ]] || die "No supported CMP 170HX found"
+
+    printf '%-16s %-16s %-8s %-14s %-8s %s\n' \
+        "GPU" "Upstream" "LnkSta" "Current speed" "Width" "Result"
+    for gpu in "${gpus[@]}"; do
+        bridge="$(basename "$(dirname "$(readlink -f "/sys/bus/pci/devices/${gpu}")")")"
+        status="$(setpci -s "${gpu}" CAP_EXP+12.w 2>/dev/null || echo unreadable)"
+        generation="$(link_generation "${gpu}")"
+        speed="$(cat "/sys/bus/pci/devices/${gpu}/current_link_speed" 2>/dev/null || echo unknown)"
+        width="$(cat "/sys/bus/pci/devices/${gpu}/current_link_width" 2>/dev/null || echo unknown)"
+        max_speed="$(cat "/sys/bus/pci/devices/${gpu}/max_link_speed" 2>/dev/null || echo unknown)"
+        if [[ "${generation}" =~ ^[0-9]+$ ]] && (( generation >= 2 )); then
+            result="GEN2 OK"
+        else
+            result="GEN1"
+            failures=$((failures + 1))
+        fi
+        printf '%-16s %-16s %-8s %-14s x%-7s %s\n' \
+            "${gpu}" "${bridge}" "0x${status}" "${speed}" "${width}" "${result}"
+        info "${gpu}: sysfs max=${max_speed}; negotiated generation is authoritative"
+    done
+
+    if command -v nvidia-smi >/dev/null; then
+        echo
+        nvidia-smi \
+            --query-gpu=pci.bus_id,memory.total,pcie.link.gen.current,pcie.link.gen.max \
+            --format=csv 2>/dev/null || true
+    fi
+
+    echo
+    if [[ -f "${LOG_FILE}" ]]; then
+        info "Last early-retrain log:"
+        tail -n 30 "${LOG_FILE}"
+    else
+        warn "No ${LOG_FILE}; the early service has not run yet"
+    fi
+
+    if (( failures > 0 )); then
+        die "${failures} GPU(s) are still negotiated at Gen1"
+    fi
+    ok "All supported GPUs are negotiated at Gen2 or better"
+}
+
+case "${1:-}" in
+    install) install_service ;;
+    remove) remove_service ;;
+    verify) verify_links ;;
+    status) show_status ;;
+    -h|--help|"") usage ;;
+    *) usage >&2; exit 1 ;;
+esac

--- a/verify.sh
+++ b/verify.sh
@@ -188,4 +188,13 @@ fi
 
 echo ""
 ok "All ${#GPU_BDFS[@]} unlockable GPU(s) report unlocked memory"
+
+if [[ -x "${SCRIPT_DIR}/tools/cmp-gen2-service.sh" ]]; then
+    echo ""
+    info "Checking negotiated PCIe generation"
+    if ! "${SCRIPT_DIR}/tools/cmp-gen2-service.sh" verify; then
+        warn "Memory unlock is healthy, but PCIe Gen2 is not active"
+        exit 1
+    fi
+fi
 exit 0


### PR DESCRIPTION
## Summary

This adds a bounded early-boot PCIe Gen2 retrain service for CMP 170HX cards
whose `0007-pcie-gen2.patch` capability window closes before the existing
probe-time retrain runs.

- retrains from the dynamically discovered upstream PCI bridge every 50 ms
  during a bounded 30-second early-boot window
- strictly guards NVIDIA vendor ID, `20c2`/`2082` device IDs, and upstream
  PCI-bridge class before writing PCI configuration space
- installs and enables the service without touching the live desktop link
- adds explicit `install`, `verify`, and `remove` controls
- integrates service setup, verification, and removal with the project scripts
- fixes the `0008` success check so an endpoint that does not set the optional
  `PCI_EXP_LNKSTA_DLLLA` bit is not reported as failed after reaching Gen2
- documents a complete 10 GB `10de:2082` validation and its reporting
  differences from the published 8 GB result

The timing mechanism is adapted from
[`studebaker8/cmp170hx-gen2`](https://github.com/studebaker8/cmp170hx-gen2)
(MIT). This PR integrates it with cmpunlocker and adds device/bridge guards,
bounded execution, rollback, verification, and 10 GB validation.

## Root cause

On the tested `2082` card, patch `0007` exposed `LnkCap2=0x06` at 7.804 seconds
after boot. The existing kernel retrain ran at 10.708 seconds, after the useful
window. Starting a root-port retrain loop during early boot caught the window
at iteration 4:

```text
[7.662] early retrain started
[7.804] driver: CAP2=0x00000006
[7.918] SUCCESS Gen2 at iteration 4; LnkSta=0x1042
```

The existing `0008` check later printed a false failure with
`status=0x1042`. The low four bits already encode Gen2; the false negative came
from also requiring `PCI_EXP_LNKSTA_DLLLA`, which was not set on this endpoint.

## 10 GB validation configuration

| Component | Configuration |
|---|---|
| GPU | CMP 170HX 10 GB, `10de:2082`, revision A1 |
| VBIOS | `92.00.66.00.02` |
| Driver | NVIDIA open kernel module `610.43.02` |
| Memory / max SM | `40960 MiB` / `1410 MHz` |
| OS / kernel | Ubuntu 26.04 LTS / `7.0.0-28-generic` |
| CPU / board | Xeon E5-2690 v4 / Supermicro X10DRG-Q |
| GPU / upstream BDF | `0000:02:00.0` / `0000:00:03.0` |
| Upstream port | Intel `8086:6f08`, 8.0 GT/s x16 capable |

IOMMU passthrough was enabled on the tested boot, but this helper does not use
IOMMU and this is not evidence that IOMMU is required.

## Results

| Measurement | Before | After |
|---|---:|---:|
| `LnkSta` | `0x1041` | `0x1042` |
| sysfs current speed | 2.5 GT/s | 5.0 GT/s |
| Link width | x4 | x4 |
| Pinned H2D | approximately 0.82 GB/s | 1.633 GB/s |
| Pinned D2H | approximately 0.84 GB/s | 1.679 GB/s |
| Unlocked memory | 40960 MiB | 40960 MiB |

No AER errors, NVIDIA Xids, or fallen-off-bus messages were observed.

Unlike the published 8 GB result, this 10 GB configuration continued to report
NVML `pcie.link.gen.current=1`/`max=1`, and sysfs maximum capability returned to
2.5 GT/s after the transient window closed. PCI configuration
`LnkSta=0x1042`, sysfs negotiated speed of 5.0 GT/s, and the doubled transfer
bandwidth are therefore used as the authoritative success criteria.

Full details are in
[`docs/gen2-10gb-2082-validation.md`](docs/gen2-10gb-2082-validation.md).

## Validation performed

- `bash -n` on all modified and added shell scripts
- `git diff --check`
- `systemd-analyze verify` on the installed unit
- applied patches `0001` through `0008` in order to a clean
  `open-gpu-kernel-modules-610.43.02` source tree
- cold-boot runtime validation at `5.0 GT/s x4`
- 512 MiB pinned PyTorch H2D/D2H test, 2 warmups and 8 measured copies
- checked current boot for PCIe AER, NVIDIA Xid, and fallen-off-bus errors

This remains a single-card, single-host validation, so the PR is opened as a
draft.
