### PR TITLE
added dkms removal mechanism

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -271,6 +271,16 @@ ok "NVIDIA driver ${detected} is supported"
 [[ -d "/lib/modules/$(uname -r)/build" ]] || die "Kernel headers missing for $(uname -r). Install linux-headers-$(uname -r) or kernel-devel."
 ok "Kernel headers present for $(uname -r)"
 
+step "Step 4b/6: Removing Nvidia DKMS modules"
+info "Not all systems feature default DKMS modules"
+
+for ver in "${SUPPORTED_VERSIONS[@]}"; do
+    dkms remove nvidia/"${ver}" --all 2>/dev/null || true
+done
+
+depmod -a "$(uname -r)"
+ok "DKMS conflicting modules resolution complete"
+
 step "Step 5/6: Building and installing patched modules"
 chmod +x "${SCRIPT_DIR}/driver/build.sh"
 CMPUNLOCKER_DRIVER_VERSION="${detected}" \
@@ -469,5 +479,6 @@ if (( CONFIGURE_GEN2_SERVICE == 1 )); then
     echo -e "     Recovery boot option: ${CYAN}systemd.mask=gen2.service${NC}"
 fi
 echo ""
+echo "This script removed the nvidia DKMS kernel modules. You will need to re-run this script after each kernel upgrade"
 echo "Log saved to: ${LOG_FILE}"
 echo ""


### PR DESCRIPTION
## Summary
The nvidia .run driver installer also installs DKMS to keep the kernel modules up to date and rebuild when the kernel updates. 
This created a conflict because the DKMS modules were always prioritized for some reason instead of the modified ones, which resulted in no unlock, as they are the vanilla software.

NOTE: There are other ways of installing the specific version 610.43.** of the driver, this fix is for people who installed it only via the .run because the .run definitely installs DKMS as well.

## Changes
- Added additional step to the install.sh script 4b/6 which runs the dkms remove command

## Testing
This is NOT tested from the install.sh script, I have tested it by running the dkms remove commands AFTER install.sh ran.
After that I had to run depmod and update-initramfs commands.
Though the dkms removal step 4b/6 is at the proper place before build.sh runs the depmod and initramfs updates - so it is expected to work.
