### PR TITLE
Raise RM thread-state timeout for unlocked cards

### DIFF
--- a/driver/build.sh
+++ b/driver/build.sh
@@ -50,6 +50,7 @@ PATCH_ORDER=(
     late-pma.patch
     bar0-pramin-clamp.patch
     ce-scrub-workarounds.patch
+    scrub-watchdog-timeout.patch
     persistent-sw-state.patch
     pcie-gen2.patch
     pcie-gen2-probe-retrain.patch

--- a/driver/patches/scrub-watchdog-timeout.patch
+++ b/driver/patches/scrub-watchdog-timeout.patch
@@ -1,0 +1,24 @@
+--- a/src/nvidia/arch/nvalloc/unix/src/os.c
++++ b/src/nvidia/arch/nvalloc/unix/src/os.c
+@@ -2144,6 +2144,21 @@
+         }
+     }
+ 
++    //
++    // CMP 170HX / 90HX with the memory unlock: these boards enumerate in
++    // graphics mode and inherit its 4 second thread-state budget, but the
++    // unlock grows the framebuffer up to 8x stock. When a process dies
++    // holding most of it, scrubbing the freed (often heavily fragmented)
++    // range can exceed 4 seconds; _scrubWaitAndSave then hits NV_ERR_TIMEOUT
++    // and RM cannot create new CUDA contexts until reboot. Give these cards
++    // double the compute-mode budget.
++    //
++    if (((pGpu->idInfo.PCIDeviceID >> 16) == 0x20C2) ||
++        ((pGpu->idInfo.PCIDeviceID >> 16) == 0x2082))
++    {
++        *pTimeoutUs = 60 * 1000000;
++    }
++
+     *pFlags = GPU_TIMEOUT_FLAGS_OSTIMER;
+ 
+     *pScale = 1;

--- a/driver/patches/scrub-watchdog-timeout.patch
+++ b/driver/patches/scrub-watchdog-timeout.patch
@@ -1,18 +1,9 @@
 --- a/src/nvidia/arch/nvalloc/unix/src/os.c
 +++ b/src/nvidia/arch/nvalloc/unix/src/os.c
-@@ -2144,6 +2144,21 @@
+@@ -2144,6 +2144,12 @@
          }
      }
  
-+    //
-+    // CMP 170HX / 90HX with the memory unlock: these boards enumerate in
-+    // graphics mode and inherit its 4 second thread-state budget, but the
-+    // unlock grows the framebuffer up to 8x stock. When a process dies
-+    // holding most of it, scrubbing the freed (often heavily fragmented)
-+    // range can exceed 4 seconds; _scrubWaitAndSave then hits NV_ERR_TIMEOUT
-+    // and RM cannot create new CUDA contexts until reboot. Give these cards
-+    // double the compute-mode budget.
-+    //
 +    if (((pGpu->idInfo.PCIDeviceID >> 16) == 0x20C2) ||
 +        ((pGpu->idInfo.PCIDeviceID >> 16) == 0x2082))
 +    {


### PR DESCRIPTION
## Summary

Adds `scrub-watchdog-timeout.patch`, which raises the RM thread-state timeout to 60 seconds for `10de:20c2` / `10de:2082`. Without it, scrubbing a freed framebuffer range on an unlocked card can exceed the 4 second graphics-mode budget, after which RM refuses to create new CUDA contexts until the machine is rebooted.

## Changes

- **`driver/patches/scrub-watchdog-timeout.patch`** (new). Overrides `*pTimeoutUs` to 60s in `osGetTimeoutParams()` for the two unlockable device IDs.
  - `osGetTimeoutParams()` assigns `NV_GPU_MODE_GRAPHICS_MODE` a 4 second budget and `NV_GPU_MODE_COMPUTE_MODE` 30 seconds.
  - The 170HX/90HX enumerate in graphics mode, so they inherit the 4 second value, but the memory unlock grows the framebuffer up to 8x stock.
  - When a process exits holding most of 64GB, scrubbing that (often heavily fragmented) range can run past 4 seconds. `_scrubWaitAndSave` then returns `NV_ERR_TIMEOUT` and the GPU stops accepting new contexts until reboot.
  - 60s was chosen as double the existing compute-mode budget.
- **`driver/build.sh`**: registers the patch in `PATCH_ORDER`, after `ce-scrub-workarounds.patch`.
  - It touches `src/nvidia/arch/nvalloc/unix/src/os.c`, which no other patch in `PATCH_ORDER` modifies, so its position is not load-bearing.

## Testing

**Patch application** — applied on top of `fe53796` against `open-gpu-kernel-modules` 610.43.02. The full 11-patch `PATCH_ORDER` stack applies cumulatively with **0 rejects**, and the resulting tree carries the override at `src/nvidia/arch/nvalloc/unix/src/os.c:2159`.

**Runtime** — the 60 second budget is confirmed active on the card below; `dmesg` reports:

```
NVRM: GPU0 timeoutRegistryOverride: Overriding default timeout to 0x03938700
```

`0x03938700` = 60,000,000 µs = 60s.

**Scope of proof — please read.** On this machine the 60s value has so far been reached via the `RmDefaultTimeout=60000` registry key (set in `/etc/modprobe.d/`), which is the workaround this patch is meant to replace. I have verified that the patch applies cleanly, builds, and produces the same 60s budget in source, but I have **not** yet isolated the in-driver path by removing the regkey and cold-booting on the patched module alone. If you want that isolation run before merging, say so and I will post the dmesg from a regkey-free boot.

**Hardware tested on (if applicable):**
- GPU variant: CMP 170HX, `10de:20c2`, 8GB → 64GB profile (reports 65536 MiB, memory verified end-to-end)
- PCIe slot / host: AMD Threadripper 1950X on X399, CPU-attached slot, link negotiates Gen2 x4
- Kernel / OS: 7.0.0-28-generic, Linux Mint 22.3, nvidia-open 610.43.02
