### PR TITLE
Leave the high reserved region reserved: it backs WPR2

### DIFF
--- a/driver/patches/late-pma.patch
+++ b/driver/patches/late-pma.patch
@@ -1,6 +1,6 @@
 diff -Naur a/src/nvidia/arch/nvalloc/unix/src/osinit.c b/src/nvidia/arch/nvalloc/unix/src/osinit.c
---- a/src/nvidia/arch/nvalloc/unix/src/osinit.c	2026-08-19 03:24:46.108123810 -0400
-+++ b/src/nvidia/arch/nvalloc/unix/src/osinit.c	2026-08-19 03:25:07.298738986 -0400
+--- a/src/nvidia/arch/nvalloc/unix/src/osinit.c	2026-08-19 03:41:39.015519805 -0400
++++ b/src/nvidia/arch/nvalloc/unix/src/osinit.c	2026-08-19 03:41:39.044946754 -0400
 @@ -2195,6 +2195,18 @@
          goto shutdown;
      }
@@ -21,8 +21,8 @@ diff -Naur a/src/nvidia/arch/nvalloc/unix/src/osinit.c b/src/nvidia/arch/nvalloc
      // Expanded GPU visibility in GPUMGR is no longer needed once the
      // GPU is initialized.
 diff -Naur a/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h b/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h
---- a/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h	2026-08-19 03:24:46.108488465 -0400
-+++ b/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h	2026-08-19 03:25:07.300260367 -0400
+--- a/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h	2026-08-19 03:41:39.026328464 -0400
++++ b/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h	2026-08-19 03:41:39.046046500 -0400
 @@ -1,3 +1,5 @@
  
  #include "g_mem_mgr_nvoc.h"
@@ -30,8 +30,8 @@ diff -Naur a/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h b/src/nvidia/inc/kernel
 +NV_STATUS memmgrSec2DebugLateExtendHighPmaRegion(OBJGPU *pGpu, MemoryManager *pMemoryManager);
 +
 diff -Naur a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c b/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c
---- a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c	2026-08-19 03:24:46.108835458 -0400
-+++ b/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c	2026-08-19 03:25:07.334768816 -0400
+--- a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c	2026-08-19 03:41:39.039732421 -0400
++++ b/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c	2026-08-19 03:41:39.063037961 -0400
 @@ -1163,6 +1163,35 @@
          }
  
@@ -68,7 +68,7 @@ diff -Naur a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c b/src/nvidia/src/kernel
      }
  
      return status;
-@@ -3646,6 +3675,113 @@
+@@ -3646,6 +3675,106 @@
      return status;
  }
  
@@ -164,13 +164,6 @@ diff -Naur a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c b/src/nvidia/src/kernel
 +        return NV_OK;
 +    }
 +
-+    //
-+    // Report the region but leave it reserved. On both the 8GB and the 10GB
-+    // SKU the highest reserved region is where the unlock relocates WPR2, so
-+    // it holds live GSP firmware and its heap rather than stranded memory.
-+    // Registering it into PMA lets allocations land on the firmware once the
-+    // main pool is exhausted.
-+    //
 +    NV_PRINTF(LEVEL_ERROR,
 +              "SEC2_DEBUG_LATE_PMA: candidate=%u base=0x%llx limit=0x%llx left reserved "
 +              "(backs WPR2)\n",
@@ -182,7 +175,7 @@ diff -Naur a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c b/src/nvidia/src/kernel
  
  /*!
   * @brief Retrieve the size of the client FB address space
-@@ -4138,7 +4274,9 @@
+@@ -4138,7 +4267,9 @@
  
      if (!bFifoLite && !RMCFG_FEATURE_PLATFORM_GSP && bVirtualMode &&
          IS_SILICON(pGpu) && !pMemorySystemConfig->bDisableCompbitBacking &&

--- a/driver/patches/late-pma.patch
+++ b/driver/patches/late-pma.patch
@@ -1,6 +1,6 @@
 diff -Naur a/src/nvidia/arch/nvalloc/unix/src/osinit.c b/src/nvidia/arch/nvalloc/unix/src/osinit.c
---- a/src/nvidia/arch/nvalloc/unix/src/osinit.c	2026-07-18 11:26:26.875698119 -0700
-+++ b/src/nvidia/arch/nvalloc/unix/src/osinit.c	2026-07-18 11:26:26.876734803 -0700
+--- a/src/nvidia/arch/nvalloc/unix/src/osinit.c	2026-08-19 03:24:46.108123810 -0400
++++ b/src/nvidia/arch/nvalloc/unix/src/osinit.c	2026-08-19 03:25:07.298738986 -0400
 @@ -2195,6 +2195,18 @@
          goto shutdown;
      }
@@ -21,8 +21,8 @@ diff -Naur a/src/nvidia/arch/nvalloc/unix/src/osinit.c b/src/nvidia/arch/nvalloc
      // Expanded GPU visibility in GPUMGR is no longer needed once the
      // GPU is initialized.
 diff -Naur a/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h b/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h
---- a/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h	2026-07-18 11:26:26.869459809 -0700
-+++ b/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h	2026-07-18 11:26:26.870506938 -0700
+--- a/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h	2026-08-19 03:24:46.108488465 -0400
++++ b/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h	2026-08-19 03:25:07.300260367 -0400
 @@ -1,3 +1,5 @@
  
  #include "g_mem_mgr_nvoc.h"
@@ -30,8 +30,8 @@ diff -Naur a/src/nvidia/inc/kernel/gpu/mem_mgr/mem_mgr.h b/src/nvidia/inc/kernel
 +NV_STATUS memmgrSec2DebugLateExtendHighPmaRegion(OBJGPU *pGpu, MemoryManager *pMemoryManager);
 +
 diff -Naur a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c b/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c
---- a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c	2026-07-18 11:26:26.862962399 -0700
-+++ b/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c	2026-07-18 11:26:26.864088597 -0700
+--- a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c	2026-08-19 03:24:46.108835458 -0400
++++ b/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c	2026-08-19 03:25:07.334768816 -0400
 @@ -1163,6 +1163,35 @@
          }
  
@@ -68,7 +68,7 @@ diff -Naur a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c b/src/nvidia/src/kernel
      }
  
      return status;
-@@ -3646,6 +3675,181 @@
+@@ -3646,6 +3675,113 @@
      return status;
  }
  
@@ -81,13 +81,11 @@ diff -Naur a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c b/src/nvidia/src/kernel
 +{
 +    Heap *pHeap;
 +    PMA *pPma;
-+    PMA_REGION_DESCRIPTOR pmaRegion = {0};
 +    PMA_REGION_DESCRIPTOR *pFirstPmaRegionDesc = NULL;
 +    FB_REGION_DESCRIPTOR *pCandidate = NULL;
 +    NvU32 numPmaRegions = 0;
 +    NvU32 candidateIdx = MAX_FB_REGIONS;
-+    NvU64 pmaFreeBefore = 0, pmaTotalBefore = 0;
-+    NvU64 pmaFreeAfter = 0, pmaTotalAfter = 0;
++    NvU64 pmaFree = 0, pmaTotal = 0;
 +    NvU64 heapFree = 0, heapTotal = 0;
 +    NvU32 devId;
 +    NvU64 stockFbBytes;
@@ -98,7 +96,7 @@ diff -Naur a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c b/src/nvidia/src/kernel
 +        return NV_ERR_INVALID_ARGUMENT;
 +
 +    devId = pGpu->idInfo.PCIDeviceID >> 16;
-+    if (devId != 0x20C2)
++    if (devId != 0x20C2 && devId != 0x2082)
 +        return NV_OK;
 +
 +    stockFbBytes = 0x200000000ULL;
@@ -116,8 +114,8 @@ diff -Naur a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c b/src/nvidia/src/kernel
 +    pPma = pHeap->pPmaObject;
 +    heapGetFree(pHeap, &heapFree);
 +    heapGetSize(pHeap, &heapTotal);
-+    pmaGetFreeMemory(pPma, &pmaFreeBefore);
-+    pmaGetTotalMemory(pPma, &pmaTotalBefore);
++    pmaGetFreeMemory(pPma, &pmaFree);
++    pmaGetTotalMemory(pPma, &pmaTotal);
 +
 +    for (i = 0; i < pMemoryManager->Ram.numFBRegions; i++)
 +    {
@@ -142,7 +140,7 @@ diff -Naur a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c b/src/nvidia/src/kernel
 +              "stockFb=0x%llx pma_total=0x%llx pma_free=0x%llx "
 +              "heap_total=0x%llx heap_free=0x%llx\n",
 +              pMemoryManager->Ram.numFBRegions, numPmaRegions,
-+              stockFbBytes, pmaTotalBefore, pmaFreeBefore,
++              stockFbBytes, pmaTotal, pmaFree,
 +              heapTotal, heapFree);
 +
 +    for (i = 0; i < pMemoryManager->Ram.numFBRegions; i++)
@@ -166,91 +164,25 @@ diff -Naur a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c b/src/nvidia/src/kernel
 +        return NV_OK;
 +    }
 +
-+    pmaRegion.base = NV_MAX(pCandidate->base, stockFbBytes);
-+    pmaRegion.limit = pCandidate->limit;
-+    pmaRegion.performance = pCandidate->performance;
-+    pmaRegion.bSupportCompressed = NV_TRUE;
-+    pmaRegion.bSupportISO = pCandidate->bSupportISO;
-+    pmaRegion.bProtected = pCandidate->bProtected;
-+
-+    if (pmaRegion.base > pmaRegion.limit)
-+    {
-+        NV_PRINTF(LEVEL_ERROR,
-+                  "SEC2_DEBUG_LATE_PMA: empty range base=0x%llx > limit=0x%llx\n",
-+                  pmaRegion.base, pmaRegion.limit);
-+        return NV_OK;
-+    }
-+
-+    if (pmaIsPmaManaged(pPma, pmaRegion.base, pmaRegion.limit))
-+    {
-+        NV_PRINTF(LEVEL_ERROR,
-+                  "SEC2_DEBUG_LATE_PMA: already managed base=0x%llx limit=0x%llx\n",
-+                  pmaRegion.base, pmaRegion.limit);
-+        return NV_OK;
-+    }
-+
++    //
++    // Report the region but leave it reserved. On both the 8GB and the 10GB
++    // SKU the highest reserved region is where the unlock relocates WPR2, so
++    // it holds live GSP firmware and its heap rather than stranded memory.
++    // Registering it into PMA lets allocations land on the firmware once the
++    // main pool is exhausted.
++    //
 +    NV_PRINTF(LEVEL_ERROR,
-+              "SEC2_DEBUG_LATE_PMA: registering candidate=%u base=0x%llx limit=0x%llx "
-+              "cand_base=0x%llx cand_limit=0x%llx pma_region_id=%u\n",
-+              candidateIdx, pmaRegion.base, pmaRegion.limit,
-+              pCandidate->base, pCandidate->limit, numPmaRegions);
++              "SEC2_DEBUG_LATE_PMA: candidate=%u base=0x%llx limit=0x%llx left reserved "
++              "(backs WPR2)\n",
++              candidateIdx, pCandidate->base, pCandidate->limit);
 +
-+    if (pCandidate->base < stockFbBytes &&
-+        pMemoryManager->Ram.numFBRegions >= MAX_FB_REGIONS)
-+    {
-+        NV_PRINTF(LEVEL_ERROR,
-+                  "SEC2_DEBUG_LATE_PMA: no FB region slot for split, "
-+                  "numRegions=%u max=%u\n",
-+                  pMemoryManager->Ram.numFBRegions, MAX_FB_REGIONS);
-+        return NV_ERR_INSUFFICIENT_RESOURCES;
-+    }
-+
-+    status = pmaRegisterRegion(pPma, numPmaRegions, NV_FALSE, &pmaRegion, 0, NULL);
-+
-+    if (status == NV_OK)
-+    {
-+        if (pCandidate->base < stockFbBytes)
-+        {
-+            FB_REGION_DESCRIPTOR publicRegion = *pCandidate;
-+            publicRegion.base = stockFbBytes;
-+            publicRegion.limit = pCandidate->limit;
-+            publicRegion.rsvdSize = 0;
-+            publicRegion.bRsvdRegion = NV_FALSE;
-+            publicRegion.bInternalHeap = NV_FALSE;
-+            publicRegion.bSupportCompressed = NV_FALSE;
-+
-+            pCandidate->limit = stockFbBytes - 1;
-+            pCandidate->rsvdSize = NV_MIN(pCandidate->rsvdSize,
-+                                          pCandidate->limit - pCandidate->base + 1);
-+
-+            pMemoryManager->Ram.fbRegion[pMemoryManager->Ram.numFBRegions] = publicRegion;
-+            pMemoryManager->Ram.numFBRegions++;
-+        }
-+        else
-+        {
-+            pCandidate->bRsvdRegion = NV_FALSE;
-+            pCandidate->rsvdSize = 0;
-+            pCandidate->bInternalHeap = NV_FALSE;
-+            pCandidate->bSupportCompressed = NV_FALSE;
-+        }
-+        memmgrRegenerateFbRegionPriority(pGpu, pMemoryManager);
-+    }
-+
-+    pmaGetFreeMemory(pPma, &pmaFreeAfter);
-+    pmaGetTotalMemory(pPma, &pmaTotalAfter);
-+
-+    NV_PRINTF(LEVEL_ERROR,
-+              "SEC2_DEBUG_LATE_PMA: status=0x%x pma_total 0x%llx->0x%llx "
-+              "pma_free 0x%llx->0x%llx\n",
-+              status, pmaTotalBefore, pmaTotalAfter, pmaFreeBefore, pmaFreeAfter);
-+
-+    return status;
++    return NV_OK;
 +}
 +
  
  /*!
   * @brief Retrieve the size of the client FB address space
-@@ -4138,7 +4342,9 @@
+@@ -4138,7 +4274,9 @@
  
      if (!bFifoLite && !RMCFG_FEATURE_PLATFORM_GSP && bVirtualMode &&
          IS_SILICON(pGpu) && !pMemorySystemConfig->bDisableCompbitBacking &&

--- a/driver/patches/late-pma.patch
+++ b/driver/patches/late-pma.patch
@@ -98,7 +98,7 @@ diff -Naur a/src/nvidia/src/kernel/gpu/mem_mgr/mem_mgr.c b/src/nvidia/src/kernel
 +        return NV_ERR_INVALID_ARGUMENT;
 +
 +    devId = pGpu->idInfo.PCIDeviceID >> 16;
-+    if (devId != 0x20C2 && devId != 0x2082)
++    if (devId != 0x20C2)
 +        return NV_OK;
 +
 +    stockFbBytes = 0x200000000ULL;


### PR DESCRIPTION
## Summary

`memmgrSec2DebugLateExtendHighPmaRegion` registers the highest reserved framebuffer region into PMA. On both SKUs that region is where the unlock relocates WPR2, so it holds live GSP firmware and its heap rather than stranded memory. Stop registering it; keep the diagnostics.

Supersedes this PR's original 2082-only fix — the defect is not SKU-specific.

## Changes

- `driver/patches/late-pma.patch`: drop the `pmaRegisterRegion` call and the FB-region descriptor rewrite that followed it. Keep the region walk, the PMA/heap totals, and the candidate report.

The crux, from a single `0x20C2` boot log:

```
region[6]         base=0xff7300000  limit=0xfffffffff   (141.0 MiB)
WPR meta updated  wprStart=0xff7400000  wprEnd=0xffff00000
                  heapOffset=0xff7500000  heapSize=0x6e00000
```

139 of those 141 MiB are WPR2, including the entire 110 MiB GSP heap. About 2 MiB is genuinely free.

Full derivation — including why the region sorts last in `pmaSelector` and so only bites once the main pool is exhausted — is in [this comment](https://github.com/amoghmunikote/cmpunlocker/pull/32#issuecomment-5338711882).

## Testing

- **`0x2082` / 40GB** — reported: `Xid 31 REGION_VIOLATION` at `0x9FD600000`, inside its own region 6, plus `cudaErrorIllegalAddress` during LoRA weight patching and `_scrubWaitAndSave` looping until reboot. Resolved by this change; 38 GB integrity test passes afterwards.
- **`0x20C2` / 64GB** — another user hit the same fault and this change resolved it, so the 64GB case is reproduced, not inferred.
- **`0x20C2` / 64GB** — measured here: `nvidia-smi` free 65049 → 64908 MiB, matching the 141 MiB predicted by `pma_total 0xfd8f50000->0xfe1c50000`; 0 Xid / MMU / scrub faults; vLLM back to a full-size workload with no regressions.

Cost: reported free really does drop 141 MiB, but ~139 MiB of that was WPR2, so real capacity loss is about 2 MiB.

**Hardware tested on (if applicable):**
- GPU variant: CMP 170HX `10de:20c2` (8GB/64GB) here and by one other user; `10de:2082` (10GB/40GB) reported separately
- PCIe slot / host: Threadripper 1950X on ASRock X399 Taichi, Gen2 x4 (2082 report: Razer Core X V2 USB4 eGPU on a GMKtec EVO X2)
- Kernel / OS: Ubuntu 24.04, kernel 7.0.0-28-generic, nvidia-open 610.43.02 + cmpunlocker
