### PR TITLE
verify.sh: check every card, and don't mistake a denied dmesg for missing logs

### DIFF
--- a/verify.sh
+++ b/verify.sh
@@ -63,20 +63,36 @@ if [[ -r "${INVENTORY_FILE}" ]] && [[ -s "${INVENTORY_FILE}" ]]; then
     done < "${INVENTORY_FILE}"
 else
     info "No installed gpu_inventory; enumerating via lspci"
-    mapfile -t PCI_LINES < <(lspci -nn 2>/dev/null | grep -iE '10de:20c2|10de:2082' || true)
-    [[ ${#PCI_LINES[@]} -gt 0 ]] || die "No unlockable CMP 170HX GPU found (10de:20c2 / 10de:2082)"
-    for PCI_LINE in "${PCI_LINES[@]}"; do
-        PCI="$(echo "${PCI_LINE}" | awk '{print $1}')"
-        PCI_FULL="$(normalize_bus_id "${PCI}")"
-        DEVID="$(echo "${PCI_LINE}" | grep -oE '10de:[0-9a-fA-F]{4}' | head -1 | cut -d: -f2 | tr '[:upper:]' '[:lower:]')"
-        PROF="$(profile_from_devid "${DEVID}")"
-        [[ "${PROF}" != "unsupported" ]] || continue
-        EXP="$(expected_mib_for_profile "${PROF}")"
-        GPU_BDFS+=("${PCI_FULL}")
-        GPU_DEVIDS+=("${DEVID}")
-        GPU_PROFILES+=("${PROF}")
-        GPU_EXPECTED+=("${EXP}")
+fi
+
+mapfile -t PCI_LINES < <(lspci -nn 2>/dev/null | grep -iE '10de:20c2|10de:2082' || true)
+[[ ${#PCI_LINES[@]} -gt 0 ]] || die "No unlockable CMP 170HX GPU found (10de:20c2 / 10de:2082)"
+
+untracked=0
+for PCI_LINE in "${PCI_LINES[@]}"; do
+    PCI="$(echo "${PCI_LINE}" | awk '{print $1}')"
+    PCI_FULL="$(normalize_bus_id "${PCI}")"
+
+    known=0
+    for existing in ${GPU_BDFS[@]+"${GPU_BDFS[@]}"}; do
+        [[ "${existing}" == "${PCI_FULL}" ]] && { known=1; break; }
     done
+    (( known )) && continue
+
+    DEVID="$(echo "${PCI_LINE}" | grep -oE '10de:[0-9a-fA-F]{4}' | head -1 | cut -d: -f2 | tr '[:upper:]' '[:lower:]')"
+    PROF="$(profile_from_devid "${DEVID}")"
+    [[ "${PROF}" != "unsupported" ]] || continue
+    EXP="$(expected_mib_for_profile "${PROF}")"
+    GPU_BDFS+=("${PCI_FULL}")
+    GPU_DEVIDS+=("${DEVID}")
+    GPU_PROFILES+=("${PROF}")
+    GPU_EXPECTED+=("${EXP}")
+    untracked=$((untracked + 1))
+done
+
+if (( untracked > 0 )) && [[ -r "${INVENTORY_FILE}" ]] && [[ -s "${INVENTORY_FILE}" ]]; then
+    warn "${untracked} GPU(s) present but absent from the inventory — verifying them anyway"
+    warn "Re-run install.sh to record them (the inventory predates these cards)"
 fi
 
 [[ ${#GPU_BDFS[@]} -gt 0 ]] || die "No unlockable GPUs to verify"
@@ -115,12 +131,20 @@ done
 
 step "Checking unlock logs and installed profile"
 sec2_logs="$(dmesg 2>/dev/null | grep 'SEC2_DEBUG' || true)"
+log_source="dmesg"
+if [[ -z "${sec2_logs}" ]] && command -v journalctl &>/dev/null; then
+    sec2_logs="$(journalctl -k --no-pager 2>/dev/null | grep 'SEC2_DEBUG' || true)"
+    [[ -n "${sec2_logs}" ]] && log_source="journalctl -k"
+fi
+
 if [[ -n "${sec2_logs}" ]]; then
-    ok "dmesg contains SEC2_DEBUG unlock logs"
+    ok "${log_source} contains SEC2_DEBUG unlock logs"
     info "Sample:"
     printf '%s\n' "${sec2_logs}" | tail -n 8 | sed 's/^/  /'
+elif [[ "${EUID}" -ne 0 ]] && ! dmesg &>/dev/null; then
+    warn "Cannot read kernel logs as non-root (kernel.dmesg_restrict=1); re-run with sudo"
 else
-    warn "No SEC2_DEBUG lines in dmesg (logs may have rotated; unlock can still be OK if memory is unlocked)"
+    warn "No SEC2_DEBUG lines in kernel logs (logs may have rotated; unlock can still be OK if memory is unlocked)"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

`verify.sh` can report success on GPUs it never looked at, and can report missing unlock logs on a machine whose logs are right there. Two independent causes, both fixed here.

## Changes

**`verify.sh`: reconcile the inventory against live PCI**

`gpu_inventory` is a snapshot written at install time. When it exists, `verify.sh` reads it and never enumerates PCI, so any card added after that install is silently skipped — and the script still exits 0.

On the host below, installed when only one card was present, `verify.sh` checked one GPU out of three and printed `All 1 unlockable GPU(s) report unlocked memory`. Had either of the other two dropped back to stock 8 GB, this would still have passed.

The inventory is now always reconciled against `lspci`. Cards present but absent from it are verified anyway, with a warning naming the stale inventory. Cards recorded in the inventory keep their recorded profile, so the file still carries the install-time intent — it is no longer treated as the complete set.

**`verify.sh`: read kernel logs via `journalctl -k` when `dmesg` is denied**

The `SEC2_DEBUG` check calls `dmesg` without sudo. `dmesg` reads the kernel ring buffer directly and is denied to non-root when `kernel.dmesg_restrict=1` — the default on Debian, Ubuntu, Mint and derivatives. It fails silently, and `grep` on empty output is indistinguishable from "no such lines", so a fully unlocked machine reports:

```
! No SEC2_DEBUG lines in dmesg (logs may have rotated; unlock can still be OK if memory is unlocked)
```

at the exact moment the user is trying to confirm the unlock worked.

Now falls back to `journalctl -k` (readable by `adm` / `systemd-journal` members), and when neither source is readable says so rather than claiming the logs are absent. `DEBUGGING.md` already instructs users to run `sudo dmesg | grep SEC2_DEBUG`, so the root requirement was known — `verify.sh` just did not honour it, and `install.sh` step 2 suggests `sudo ./verify.sh` while `verify.sh` itself has no `EUID` guard.

The "logs may have rotated" wording is preserved for the case it actually describes: `dmesg` runs fine but returns nothing.

## Testing

Live hardware, 3× `10de:20c2`, non-root shell, `kernel.dmesg_restrict = 1`.

**Before** (`8f3c82f`, unmodified):

```
==> Using inventory: /lib/modules/6.8.0-65-generic/updates/cmpunlocker/gpu_inventory

BDF              PCI ID   Variant  Expect       Actual       Status
0000:01:00.0     20c2     8gb      ~65536       65536        OK

! No SEC2_DEBUG lines in dmesg (logs may have rotated; unlock can still be OK if memory is unlocked)

✓ All 1 unlockable GPU(s) report unlocked memory     <- three cards installed
```

`gpu_inventory` holds a single line dated Jul 30, when this host had one card:

```
0000:01:00.0 20c2 8gb 65536
```

while `lspci -nn | grep 10de:20c2` returns `01:00.0`, `02:00.0`, `71:00.0`.

**After:**

```
==> Using inventory: /lib/modules/6.8.0-65-generic/updates/cmpunlocker/gpu_inventory
! 2 GPU(s) present but absent from the inventory — verifying them anyway
! Re-run install.sh to record them (the inventory predates these cards)

BDF              PCI ID   Variant  Expect       Actual       Status
0000:01:00.0     20c2     8gb      ~65536       65536        OK
0000:02:00.0     20c2     8gb      ~65536       65536        OK
0000:71:00.0     20c2     8gb      ~65536       65536        OK

✓ journalctl -k contains SEC2_DEBUG unlock logs
==> Sample:
  NVRM: GPU2 memmgrSec2DebugLateExtendHighPmaRegion: SEC2_DEBUG_LATE_PMA: numFBRegions=7 numPmaRegions=1 stockFb=0x200000000 pma_total=0xfd8f50000 pma_free=0xfd8f50000 heap_total=0x1000000000 heap_free=0xa133000
  NVRM: GPU2 RmInitAdapter: SEC2_DEBUG: late PMA extension status=0x0

✓ All 3 unlockable GPU(s) report unlocked memory
```

Same shell, same permissions — 228 `SEC2_DEBUG` lines were in `journalctl -k` the whole time, while `dmesg | grep -c SEC2_DEBUG` returned 0.

**Regressions checked** (all on the same live host):

| Case | Expected | Result |
|---|---|---|
| No inventory (path forced to a nonexistent kernel dir) | enumerate via lspci, no stale-inventory warning | 3 GPUs, no warning ✓ |
| Complete 3-card inventory | no warning, all verified | 0 warnings, 3 GPUs ✓ |
| `dmesg` readable (root-equivalent, via a stub earlier in `PATH`) | take the original `dmesg` path | `✓ dmesg contains SEC2_DEBUG unlock logs` — byte-identical to `8f3c82f` on the same input ✓ |
| Both sources empty (logs genuinely rotated) | keep the original "rotated" wording | `! No SEC2_DEBUG lines in kernel logs (logs may have rotated; ...)` ✓ |

`bash -n` clean. No patch, driver, or install logic touched — `verify.sh` only.

**Hardware tested on (if applicable):**
- GPU variant: CMP 170HX ×3, `10de:20c2`, 8GB → 64GB profile (all three report 65536 MiB)
- PCIe slot / host: ASUS ProArt Z690-CREATOR WIFI, triple x8/x8/x4, each card negotiates Gen2 x4
- Kernel / OS: 6.8.0-65-generic, Ubuntu 22.04, nvidia-open 610.43.02
