### PR TITLE
PCIe: harden the Gen3 retrain path

### DIFF
--- a/driver/patches/pcie-gen2-probe-retrain.patch
+++ b/driver/patches/pcie-gen2-probe-retrain.patch
@@ -11,7 +11,7 @@
  
  #include <sound/core.h>             /* HDA struct snd_card */
  
-@@ -1362,6 +1366,127 @@
+@@ -1362,6 +1366,117 @@
  #endif
  }
  
@@ -45,15 +45,6 @@
 +        return;
 +    }
 +
-+    /*
-+     * OPT_DISABLE_GEN3_SPEED (0x820250) is a hardware ceiling with no software
-+     * override: when it is set - the factory state on every CMP 170HX - the PHY
-+     * cannot do 8 GT/s at all, and LINK_CAP is min(advertised, that ceiling).
-+     * Asking the LTSSM for a speed ABOVE what LINK_CAP advertises is an
-+     * illegitimate speed change: the card leaves the bus and only a chassis
-+     * power cycle brings it back. So read the fuse, clamp to LINK_CAP, and
-+     * never request more than the hardware will actually grant.
-+     */
 +    gen3_fused = ((readl(bar0 + 0x820250) & 1U) == 0U);
 +
 +    cya0 = readl(bar0 + 0x8c2c0);
@@ -74,7 +65,6 @@
 +
 +    for (; target >= 1U; target--)
 +    {
-+        /* NV_XP_PL_LINK_CONFIG_0 MAX_LINK_RATE: 1 = 8000, 2 = 5000, 3 = 2500 */
 +        rate = (target >= 3U) ? 1U : ((target == 2U) ? 2U : 3U);
 +        link_config = readl(bar0 + 0x8c040);
 +        writel((link_config & ~0x000c0000U) | (rate << 18), bar0 + 0x8c040);
@@ -139,7 +129,7 @@
  /*
   * Brings up the device on the first file open. Assumes nvl->ldata_lock is held.
   */
-@@ -1526,6 +1651,8 @@
+@@ -1526,6 +1641,8 @@
          nv->flags |= NV_FLAG_PERSISTENT_SW_STATE;
      }
  

--- a/driver/patches/pcie-gen2-probe-retrain.patch
+++ b/driver/patches/pcie-gen2-probe-retrain.patch
@@ -36,22 +36,22 @@
 +    if (upstream == NULL)
 +    {
 +        NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
-+                      "CMP Gen2: no upstream PCIe bridge; skipping link retrain\n");
++                      "CMP Gen3: no upstream PCIe bridge; skipping link retrain\n");
 +        return;
 +    }
 +    bar0 = ioremap(pci_resource_start(gpu, 0), 0x90000);
 +    if (bar0 == NULL)
 +    {
 +        NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
-+                      "CMP Gen2: cannot map BAR0; skipping link retrain\n");
++                      "CMP Gen3: cannot map BAR0; skipping link retrain\n");
 +        return;
 +    }
 +    cya0 = readl(bar0 + 0x8c2c0);
-+    writel(cya0 & ~(1U << 2), bar0 + 0x8c2c0);
-+    link_config = readl(bar0 + 0x8c040);
-+    writel((link_config & ~0x000c0000U) | (2U << 18), bar0 + 0x8c040);
-+    writel(0x00000006U, bar0 + 0x8872c);
++    writel(cya0 & ~((1U << 2) | (1U << 0)), bar0 + 0x8c2c0);
++    writel(0x0000000AU, bar0 + 0x8872c);
 +    (void)readl(bar0 + 0x8872c);
++    link_config = readl(bar0 + 0x8c040);
++    writel((link_config & ~0x000c0000U) | (1U << 18), bar0 + 0x8c040);
 +    iounmap(bar0);
 +    msleep(50);
 +    ret = pcie_capability_read_word(gpu, PCI_EXP_LNKCTL2, &gpu_ctl2);
@@ -60,8 +60,8 @@
 +    ret = pcie_capability_read_word(upstream, PCI_EXP_LNKCTL2, &upstream_ctl2);
 +    if (ret)
 +        goto capability_error;
-+    gpu_ctl2 = (gpu_ctl2 & ~PCI_EXP_LNKCTL2_TLS) | PCI_EXP_LNKCTL2_TLS_5_0GT;
-+    upstream_ctl2 = (upstream_ctl2 & ~PCI_EXP_LNKCTL2_TLS) | PCI_EXP_LNKCTL2_TLS_5_0GT;
++    gpu_ctl2 = (gpu_ctl2 & ~PCI_EXP_LNKCTL2_TLS) | PCI_EXP_LNKCTL2_TLS_8_0GT;
++    upstream_ctl2 = (upstream_ctl2 & ~PCI_EXP_LNKCTL2_TLS) | PCI_EXP_LNKCTL2_TLS_8_0GT;
 +    ret = pcie_capability_write_word(gpu, PCI_EXP_LNKCTL2, gpu_ctl2);
 +    if (ret)
 +        goto capability_error;
@@ -81,21 +81,21 @@
 +        msleep(100);
 +        ret = pcie_capability_read_word(gpu, PCI_EXP_LNKSTA, &link_status);
 +        if (!ret &&
-+            ((link_status & PCI_EXP_LNKSTA_CLS) >= PCI_EXP_LNKSTA_CLS_5_0GB))
++            ((link_status & PCI_EXP_LNKSTA_CLS) >= PCI_EXP_LNKSTA_CLS_8_0GB))
 +        {
-+            NV_DEV_PRINTF(NV_DBG_INFO, nv, "CMP Gen2: PCIe link trained to Gen%u\n",
++            NV_DEV_PRINTF(NV_DBG_INFO, nv, "CMP Gen3: PCIe link trained to Gen%u\n",
 +                          link_status & PCI_EXP_LNKSTA_CLS);
 +            return;
 +        }
 +    }
 +
 +    NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
-+                  "CMP Gen2: PCIe retrain completed without Gen2 link (status=0x%04x, ret=%d)\n",
++                  "CMP Gen3: PCIe retrain completed without Gen3 link (status=0x%04x, ret=%d)\n",
 +                  link_status, ret);
 +    return;
 +capability_error:
 +    NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
-+                  "CMP Gen2: PCIe capability access failed (%d); skipping link retrain\n", ret);
++                  "CMP Gen3: PCIe capability access failed (%d); skipping link retrain\n", ret);
  }
  
  /*

--- a/driver/patches/pcie-gen2-probe-retrain.patch
+++ b/driver/patches/pcie-gen2-probe-retrain.patch
@@ -11,12 +11,10 @@
  
  #include <sound/core.h>             /* HDA struct snd_card */
  
-@@ -1360,6 +1364,87 @@
- #if defined(NV_UVM_ENABLE)
-     nv_uvm_resume_P2P(pUuid);
+@@ -1362,6 +1366,127 @@
  #endif
-+}
-+
+ }
+ 
 +static void
 +nv_cmp170hx_retrain_gen2(nv_state_t *nv)
 +{
@@ -25,7 +23,7 @@
 +    struct pci_dev *upstream;
 +    void __iomem *bar0;
 +    u16 gpu_ctl2, upstream_ctl2, upstream_ctl, link_status = 0;
-+    u32 cya0, link_config;
++    u32 cya0, link_config, link_cap, gen3_fused, target, rate, reached = 0;
 +    int ret, attempt;
 +
 +    if ((gpu == NULL) ||
@@ -36,70 +34,112 @@
 +    if (upstream == NULL)
 +    {
 +        NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
-+                      "CMP Gen3: no upstream PCIe bridge; skipping link retrain\n");
++                      "CMP PCIe: no upstream bridge; skipping link retrain\n");
 +        return;
 +    }
 +    bar0 = ioremap(pci_resource_start(gpu, 0), 0x90000);
 +    if (bar0 == NULL)
 +    {
 +        NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
-+                      "CMP Gen3: cannot map BAR0; skipping link retrain\n");
++                      "CMP PCIe: cannot map BAR0; skipping link retrain\n");
 +        return;
 +    }
++
++    /*
++     * OPT_DISABLE_GEN3_SPEED (0x820250) is a hardware ceiling with no software
++     * override: when it is set - the factory state on every CMP 170HX - the PHY
++     * cannot do 8 GT/s at all, and LINK_CAP is min(advertised, that ceiling).
++     * Asking the LTSSM for a speed ABOVE what LINK_CAP advertises is an
++     * illegitimate speed change: the card leaves the bus and only a chassis
++     * power cycle brings it back. So read the fuse, clamp to LINK_CAP, and
++     * never request more than the hardware will actually grant.
++     */
++    gen3_fused = ((readl(bar0 + 0x820250) & 1U) == 0U);
++
 +    cya0 = readl(bar0 + 0x8c2c0);
 +    writel(cya0 & ~((1U << 2) | (1U << 0)), bar0 + 0x8c2c0);
 +    writel(0x0000000AU, bar0 + 0x8872c);
 +    (void)readl(bar0 + 0x8872c);
-+    link_config = readl(bar0 + 0x8c040);
-+    writel((link_config & ~0x000c0000U) | (1U << 18), bar0 + 0x8c040);
-+    iounmap(bar0);
-+    msleep(50);
-+    ret = pcie_capability_read_word(gpu, PCI_EXP_LNKCTL2, &gpu_ctl2);
-+    if (ret)
-+        goto capability_error;
-+    ret = pcie_capability_read_word(upstream, PCI_EXP_LNKCTL2, &upstream_ctl2);
-+    if (ret)
-+        goto capability_error;
-+    gpu_ctl2 = (gpu_ctl2 & ~PCI_EXP_LNKCTL2_TLS) | PCI_EXP_LNKCTL2_TLS_8_0GT;
-+    upstream_ctl2 = (upstream_ctl2 & ~PCI_EXP_LNKCTL2_TLS) | PCI_EXP_LNKCTL2_TLS_8_0GT;
-+    ret = pcie_capability_write_word(gpu, PCI_EXP_LNKCTL2, gpu_ctl2);
-+    if (ret)
-+        goto capability_error;
-+    ret = pcie_capability_write_word(upstream, PCI_EXP_LNKCTL2, upstream_ctl2);
-+    if (ret)
-+        goto capability_error;
-+    ret = pcie_capability_read_word(upstream, PCI_EXP_LNKCTL, &upstream_ctl);
-+    if (ret)
-+        goto capability_error;
-+    ret = pcie_capability_write_word(upstream, PCI_EXP_LNKCTL,
-+                                     upstream_ctl | PCI_EXP_LNKCTL_RL);
-+    if (ret)
-+        goto capability_error;
++    msleep(20);
 +
-+    for (attempt = 0; attempt < 20; attempt++)
++    link_cap = readl(bar0 + 0x88084) & 0xfU;
++    target = gen3_fused ? 3U : 2U;
++    if ((link_cap != 0U) && (target > link_cap))
++        target = link_cap;
++
++    NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
++                  "CMP PCIe: DISABLE_GEN3_SPEED fuse %s, LINK_CAP max Gen%u, targeting Gen%u\n",
++                  gen3_fused ? "clear" : "SET (Gen2 is the ceiling)",
++                  link_cap, target);
++
++    for (; target >= 1U; target--)
 +    {
-+        msleep(100);
-+        ret = pcie_capability_read_word(gpu, PCI_EXP_LNKSTA, &link_status);
-+        if (!ret &&
-+            ((link_status & PCI_EXP_LNKSTA_CLS) >= PCI_EXP_LNKSTA_CLS_8_0GB))
++        /* NV_XP_PL_LINK_CONFIG_0 MAX_LINK_RATE: 1 = 8000, 2 = 5000, 3 = 2500 */
++        rate = (target >= 3U) ? 1U : ((target == 2U) ? 2U : 3U);
++        link_config = readl(bar0 + 0x8c040);
++        writel((link_config & ~0x000c0000U) | (rate << 18), bar0 + 0x8c040);
++        (void)readl(bar0 + 0x8c040);
++        msleep(50);
++
++        ret = pcie_capability_read_word(gpu, PCI_EXP_LNKCTL2, &gpu_ctl2);
++        if (ret)
++            goto capability_error;
++        ret = pcie_capability_read_word(upstream, PCI_EXP_LNKCTL2, &upstream_ctl2);
++        if (ret)
++            goto capability_error;
++        gpu_ctl2 = (gpu_ctl2 & ~PCI_EXP_LNKCTL2_TLS) | (u16)target;
++        upstream_ctl2 = (upstream_ctl2 & ~PCI_EXP_LNKCTL2_TLS) | (u16)target;
++        ret = pcie_capability_write_word(gpu, PCI_EXP_LNKCTL2, gpu_ctl2);
++        if (ret)
++            goto capability_error;
++        ret = pcie_capability_write_word(upstream, PCI_EXP_LNKCTL2, upstream_ctl2);
++        if (ret)
++            goto capability_error;
++        ret = pcie_capability_read_word(upstream, PCI_EXP_LNKCTL, &upstream_ctl);
++        if (ret)
++            goto capability_error;
++        ret = pcie_capability_write_word(upstream, PCI_EXP_LNKCTL,
++                                         upstream_ctl | PCI_EXP_LNKCTL_RL);
++        if (ret)
++            goto capability_error;
++
++        for (attempt = 0; attempt < 20; attempt++)
 +        {
-+            NV_DEV_PRINTF(NV_DBG_INFO, nv, "CMP Gen3: PCIe link trained to Gen%u\n",
-+                          link_status & PCI_EXP_LNKSTA_CLS);
-+            return;
++            msleep(100);
++            ret = pcie_capability_read_word(gpu, PCI_EXP_LNKSTA, &link_status);
++            if (ret)
++                continue;
++            reached = link_status & PCI_EXP_LNKSTA_CLS;
++            if (reached >= target)
++            {
++                NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
++                              "CMP PCIe: link trained to Gen%u\n", reached);
++                iounmap(bar0);
++                return;
++            }
 +        }
++
++        NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
++                      "CMP PCIe: Gen%u retrain did not take (link at Gen%u)%s\n",
++                      target, reached,
++                      (target > 1U) ? "; falling back one generation" : "");
 +    }
 +
 +    NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
-+                  "CMP Gen3: PCIe retrain completed without Gen3 link (status=0x%04x, ret=%d)\n",
-+                  link_status, ret);
++                  "CMP PCIe: retrain exhausted all generations (status=0x%04x)\n",
++                  link_status);
++    iounmap(bar0);
 +    return;
 +capability_error:
++    iounmap(bar0);
 +    NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
-+                  "CMP Gen3: PCIe capability access failed (%d); skipping link retrain\n", ret);
- }
- 
++                  "CMP PCIe: capability access failed (%d); skipping link retrain\n", ret);
++}
++
  /*
-@@ -1530,6 +1624,8 @@
+  * Brings up the device on the first file open. Assumes nvl->ldata_lock is held.
+  */
+@@ -1526,6 +1651,8 @@
          nv->flags |= NV_FLAG_PERSISTENT_SW_STATE;
      }
  

--- a/driver/patches/pcie-gen2-probe-retrain.patch
+++ b/driver/patches/pcie-gen2-probe-retrain.patch
@@ -11,20 +11,45 @@
  
  #include <sound/core.h>             /* HDA struct snd_card */
  
-@@ -1362,6 +1366,117 @@
+@@ -1362,6 +1366,179 @@
  #endif
  }
  
++/*
++ * Ceiling for the CMP 170HX PCIe link retrain below:
++ *   0       disable the retrain entirely
++ *   1, 2, 3 cap the target at that generation
++ *   -1      auto (default): derive the ceiling from the fuse and from both
++ *           ends of the link
++ *
++ * A forced value is a cap, never a floor, so it can only ever ask for less
++ * than the hardware reports.
++ */
++NV_DEFINE_REG_ENTRY(CmpPcieGen, ~0U);
++MODULE_PARM_DESC(NVreg_CmpPcieGen,
++                 "CMP 170HX PCIe link retrain ceiling: 0=off, 1/2/3=cap at that generation, -1=auto (default)");
++
++/*
++ * The highest BAR0 offset touched below is the fuse block at 0x820250, so the
++ * mapping has to reach past it. Mapping only the XVE window (0x90000) puts
++ * that read outside the ioremap, where it faults instead of returning a fuse.
++ */
++#define NV_CMP_BAR0_MAP_SIZE 0x821000U
++
 +static void
-+nv_cmp170hx_retrain_gen2(nv_state_t *nv)
++nv_cmp170hx_retrain_pcie(nv_state_t *nv)
 +{
 +    nv_linux_state_t *nvl = NV_GET_NVL_FROM_NV_STATE(nv);
 +    struct pci_dev *gpu = nvl->pci_dev;
 +    struct pci_dev *upstream;
 +    void __iomem *bar0;
 +    u16 gpu_ctl2, upstream_ctl2, upstream_ctl, link_status = 0;
-+    u32 cya0, link_config, link_cap, gen3_fused, target, rate, reached = 0;
++    u32 cya0, link_config, link_cap, upstream_cap, gen3_allowed;
++    u32 target, rate, reached = 0;
 +    int ret, attempt;
++
++    if (NVreg_CmpPcieGen == 0U)
++        return;
 +
 +    if ((gpu == NULL) ||
 +        ((gpu->device != 0x20c2) && (gpu->device != 0x2082)))
@@ -37,7 +62,14 @@
 +                      "CMP PCIe: no upstream bridge; skipping link retrain\n");
 +        return;
 +    }
-+    bar0 = ioremap(pci_resource_start(gpu, 0), 0x90000);
++    if (pci_resource_len(gpu, 0) < NV_CMP_BAR0_MAP_SIZE)
++    {
++        NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
++                      "CMP PCIe: BAR0 is only 0x%llx bytes; skipping link retrain\n",
++                      (unsigned long long)pci_resource_len(gpu, 0));
++        return;
++    }
++    bar0 = ioremap(pci_resource_start(gpu, 0), NV_CMP_BAR0_MAP_SIZE);
 +    if (bar0 == NULL)
 +    {
 +        NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
@@ -45,7 +77,11 @@
 +        return;
 +    }
 +
-+    gen3_fused = ((readl(bar0 + 0x820250) & 1U) == 0U);
++    /*
++     * OPT_DISABLE_GEN3_SPEED is active high, so a clear bit means Gen3 is
++     * permitted. The name below tracks what the value means, not the fuse.
++     */
++    gen3_allowed = ((readl(bar0 + 0x820250) & 1U) == 0U);
 +
 +    cya0 = readl(bar0 + 0x8c2c0);
 +    writel(cya0 & ~((1U << 2) | (1U << 0)), bar0 + 0x8c2c0);
@@ -53,18 +89,39 @@
 +    (void)readl(bar0 + 0x8872c);
 +    msleep(20);
 +
++    target = gen3_allowed ? 3U : 2U;
++
++    /* The GPU advertises its own ceiling once the CYA overrides are in place. */
 +    link_cap = readl(bar0 + 0x88084) & 0xfU;
-+    target = gen3_fused ? 3U : 2U;
 +    if ((link_cap != 0U) && (target > link_cap))
 +        target = link_cap;
 +
++    /*
++     * A link runs no faster than the slower end, so the upstream bridge caps
++     * the target as well. Asking a Gen2 slot for Gen3 only burns a retrain
++     * cycle and can leave the link unstable.
++     */
++    upstream_cap = 0U;
++    ret = pcie_capability_read_dword(upstream, PCI_EXP_LNKCAP, &upstream_cap);
++    if (ret == 0)
++    {
++        upstream_cap &= PCI_EXP_LNKCAP_SLS;
++        if ((upstream_cap != 0U) && (target > upstream_cap))
++            target = upstream_cap;
++    }
++
++    if ((NVreg_CmpPcieGen <= 3U) && (target > NVreg_CmpPcieGen))
++        target = NVreg_CmpPcieGen;
++
 +    NV_DEV_PRINTF(NV_DBG_ERRORS, nv,
-+                  "CMP PCIe: DISABLE_GEN3_SPEED fuse %s, LINK_CAP max Gen%u, targeting Gen%u\n",
-+                  gen3_fused ? "clear" : "SET (Gen2 is the ceiling)",
-+                  link_cap, target);
++                  "CMP PCIe: DISABLE_GEN3_SPEED fuse %s, GPU LINK_CAP Gen%u, "
++                  "upstream LNKCAP Gen%u, targeting Gen%u\n",
++                  gen3_allowed ? "clear" : "SET (Gen2 is the ceiling)",
++                  link_cap, upstream_cap, target);
 +
 +    for (; target >= 1U; target--)
 +    {
++        /* XVE LINK_CONFIG_0 MAX_LINK_RATE is inverted: 1 = 8G, 2 = 5G, 3 = 2.5G. */
 +        rate = (target >= 3U) ? 1U : ((target == 2U) ? 2U : 3U);
 +        link_config = readl(bar0 + 0x8c040);
 +        writel((link_config & ~0x000c0000U) | (rate << 18), bar0 + 0x8c040);
@@ -97,7 +154,12 @@
 +        {
 +            msleep(100);
 +            ret = pcie_capability_read_word(gpu, PCI_EXP_LNKSTA, &link_status);
-+            if (ret)
++            /*
++             * Config reads return all ones once the device falls off the bus.
++             * Left alone that decodes as a link trained to Gen15, which would
++             * report success for a card that just disappeared.
++             */
++            if (ret || (link_status == (u16)~0))
 +                continue;
 +            reached = link_status & PCI_EXP_LNKSTA_CLS;
 +            if (reached >= target)
@@ -129,11 +191,11 @@
  /*
   * Brings up the device on the first file open. Assumes nvl->ldata_lock is held.
   */
-@@ -1526,6 +1641,8 @@
+@@ -1526,6 +1703,8 @@
          nv->flags |= NV_FLAG_PERSISTENT_SW_STATE;
      }
  
-+    nv_cmp170hx_retrain_gen2(nv);
++    nv_cmp170hx_retrain_pcie(nv);
 +
      /* Generate and cache the UUID for future callers */
      (void)rm_get_gpu_uuid_raw(sp, nv);

--- a/driver/patches/pcie-gen2.patch
+++ b/driver/patches/pcie-gen2.patch
@@ -21,7 +21,7 @@
 +            #define PCIE_GEN2_OPT_GEN3_ADDR         0x00820580U
 +            #define PCIE_GEN2_OPT_MAGIC_ADDR        0x00820520U
 +            #define PCIE_LINK_SPEED_OF(stat)        (((stat) >> 16) & 0xFU)
-+            const NvU32 PCIE_GEN2_LINK_SPEED = 0x00000002U;
++            const NvU32 PCIE_GEN2_LINK_SPEED = 0x00000003U;
 +            const NvU32 PCIE_GEN2_PL_LINK_RATE_VALUE = 0x00240036U;
 +
 +            NvU32 capBefore = GPU_REG_RD32(pGpu, PCIE_GEN2_LINK_CAP_ADDR);
@@ -215,20 +215,20 @@
 +                lc2 = (lc2 & ~0x000F0000U) | 0x000F0000U;
 +                GPU_REG_WR32(pGpu, PCIE_GEN2_LINK_CTRL_2_ADDR, lc2);
 +                cya0 = GPU_REG_RD32(pGpu, 0x0008c2c0U);
-+                cya0 = cya0 & ~(1U << 2);
++                cya0 = cya0 & ~((1U << 2) | (1U << 0));
 +                GPU_REG_WR32(pGpu, 0x0008c2c0U, cya0);
 +                NV_PRINTF(LEVEL_ERROR,
 +                          "SEC2_DEBUG: PCIe CYA_0 after clear DIS_G2: 0x%08x (bit2=%u)\n",
 +                          GPU_REG_RD32(pGpu, 0x0008c2c0U),
 +                          (GPU_REG_RD32(pGpu, 0x0008c2c0U) >> 2) & 1U);
++                GPU_REG_WR32(pGpu, 0x0008872cU, 0x0000000AU);
++                GPU_REG_WR32(pGpu, PCIE_GEN2_PL_LINK_RATE_ADDR, PCIE_GEN2_PL_LINK_RATE_VALUE);
 +                linkCfg = GPU_REG_RD32(pGpu, 0x0008c040U);
-+                linkCfg = (linkCfg & ~0x000C0000U) | (0x2U << 18);
++                linkCfg = (linkCfg & ~0x000C0000U) | (0x1U << 18);
 +                GPU_REG_WR32(pGpu, 0x0008c040U, linkCfg);
 +                NV_PRINTF(LEVEL_ERROR,
-+                          "SEC2_DEBUG: PCIe LINK_CONFIG_0 after MAX_RATE=2: 0x%08x\n",
++                          "SEC2_DEBUG: PCIe LINK_CONFIG_0 after MAX_RATE=8G: 0x%08x\n",
 +                          GPU_REG_RD32(pGpu, 0x0008c040U));
-+                GPU_REG_WR32(pGpu, PCIE_GEN2_PL_LINK_RATE_ADDR, PCIE_GEN2_PL_LINK_RATE_VALUE);
-+                GPU_REG_WR32(pGpu, 0x0008872cU, 0x00000006U);
 +                NV_PRINTF(LEVEL_ERROR,
 +                          "SEC2_DEBUG: PCIe XVE_OVR@8872c=0x%08x; skip mid-boot retrain\n",
 +                          GPU_REG_RD32(pGpu, 0x0008872cU));
@@ -285,19 +285,19 @@
 +                      GPU_REG_RD32(pGpu, PCIE_GEN2_PRIV_MISC_1_ADDR_LATE));
 +            {
 +                NvU32 cyaLate = GPU_REG_RD32(pGpu, 0x0008c2c0U);
-+                cyaLate = cyaLate & ~(1U << 2);
++                cyaLate = cyaLate & ~((1U << 2) | (1U << 0));
 +                GPU_REG_WR32(pGpu, 0x0008c2c0U, cyaLate);
 +                NV_PRINTF(LEVEL_ERROR,
 +                          "SEC2_DEBUG: PCIe CYA_0 late clear DIS_G2: 0x%08x (bit2=%u)\n",
 +                          GPU_REG_RD32(pGpu, 0x0008c2c0U),
 +                          (GPU_REG_RD32(pGpu, 0x0008c2c0U) >> 2) & 1U);
++                GPU_REG_WR32(pGpu, 0x0008872cU, 0x0000000AU);
 +                NvU32 linkCfgLate = GPU_REG_RD32(pGpu, 0x0008c040U);
-+                linkCfgLate = (linkCfgLate & ~0x000C0000U) | (0x2U << 18);
++                linkCfgLate = (linkCfgLate & ~0x000C0000U) | (0x1U << 18);
 +                GPU_REG_WR32(pGpu, 0x0008c040U, linkCfgLate);
 +                NV_PRINTF(LEVEL_ERROR,
-+                          "SEC2_DEBUG: PCIe LINK_CONFIG_0 late MAX_RATE=2: 0x%08x\n",
++                          "SEC2_DEBUG: PCIe LINK_CONFIG_0 late MAX_RATE=8G: 0x%08x\n",
 +                          GPU_REG_RD32(pGpu, 0x0008c040U));
-+                GPU_REG_WR32(pGpu, 0x0008872cU, 0x00000006U);
 +                NV_PRINTF(LEVEL_ERROR,
 +                          "SEC2_DEBUG: PCIe XVE_OVR late=0x%08x\n",
 +                          GPU_REG_RD32(pGpu, 0x0008872cU));

--- a/driver/patches/pcie-gen2.patch
+++ b/driver/patches/pcie-gen2.patch
@@ -1,6 +1,51 @@
+--- /dev/null
++++ b/src/nvidia/inc/kernel/gpu/gsp/cmp_pcie.h
+@@ -0,0 +1,34 @@
++/*
++ * CMP 170HX PCIe link speed policy.
++ *
++ * Two RM paths raise the link ceiling: the mid-boot path in kernel_gsp.c and
++ * the post-Booter-Load path in kernel_gsp_tu102.c. Both have to agree on the
++ * target, so the decision lives here instead of being spelled out twice.
++ *
++ * These paths only set the ceiling. The retrain itself, including the fall
++ * back one generation at a time, happens later in nv_cmp170hx_retrain_pcie()
++ * (kernel-open/nvidia/nv.c).
++ */
++
++#ifndef CMP_PCIE_H
++#define CMP_PCIE_H
++
++#define CMP_PCIE_FUSE_OPT_DISABLE_GEN3_SPEED    0x00820250U
++
++/*
++ * The fuse is active high, so a clear bit means Gen3 is permitted. The macro
++ * name tracks what the value means rather than the polarity of the bit.
++ */
++#define CMP_PCIE_GEN3_ALLOWED(pGpu) \
++    ((GPU_REG_RD32(pGpu, CMP_PCIE_FUSE_OPT_DISABLE_GEN3_SPEED) & 1U) == 0U)
++
++#define CMP_PCIE_TARGET_GEN(pGpu)   (CMP_PCIE_GEN3_ALLOWED(pGpu) ? 3U : 2U)
++
++/*
++ * XVE LINK_CONFIG_0 MAX_LINK_RATE (bits 19:18) runs opposite to the generation
++ * number: 1 = 8.0 GT/s, 2 = 5.0 GT/s, 3 = 2.5 GT/s.
++ */
++#define CMP_PCIE_MAX_LINK_RATE(gen) \
++    (((gen) >= 3U) ? 0x1U : (((gen) == 2U) ? 0x2U : 0x3U))
++
++#endif // CMP_PCIE_H
 --- a/src/nvidia/src/kernel/gpu/gsp/kernel_gsp.c
 +++ b/src/nvidia/src/kernel/gpu/gsp/kernel_gsp.c
-@@ -4922,6 +4922,262 @@
+@@ -24,6 +24,7 @@
+ #include "resserv/rs_server.h"
+ 
+ #include "gpu/gsp/kernel_gsp.h"
++#include "gpu/gsp/cmp_pcie.h"
+ #include "gpu/falcon/kernel_falcon.h"
+ 
+ #include "kernel/core/thread_state.h"
+@@ -4922,6 +4923,262 @@
                        GPU_REG_RD32(pGpu, 0x00100ce0U));
          }
  
@@ -21,8 +66,7 @@
 +            #define PCIE_GEN2_OPT_GEN3_ADDR         0x00820580U
 +            #define PCIE_GEN2_OPT_MAGIC_ADDR        0x00820520U
 +            #define PCIE_LINK_SPEED_OF(stat)        (((stat) >> 16) & 0xFU)
-+            const NvU32 PCIE_GEN2_LINK_SPEED =
-+                (((GPU_REG_RD32(pGpu, 0x00820250U) & 1U) == 0U) ? 3U : 2U);
++            const NvU32 targetGen = CMP_PCIE_TARGET_GEN(pGpu);
 +            const NvU32 PCIE_GEN2_PL_LINK_RATE_VALUE = 0x00240036U;
 +
 +            NvU32 capBefore = GPU_REG_RD32(pGpu, PCIE_GEN2_LINK_CAP_ADDR);
@@ -212,7 +256,7 @@
 +                NvU32 lc2 = GPU_REG_RD32(pGpu, PCIE_GEN2_LINK_CTRL_2_ADDR);
 +                NvU32 linkCfg;
 +                NvU32 cya0;
-+                lc2 = (lc2 & ~0x0000000FU) | PCIE_GEN2_LINK_SPEED;
++                lc2 = (lc2 & ~0x0000000FU) | targetGen;
 +                lc2 = (lc2 & ~0x000F0000U) | 0x000F0000U;
 +                GPU_REG_WR32(pGpu, PCIE_GEN2_LINK_CTRL_2_ADDR, lc2);
 +                cya0 = GPU_REG_RD32(pGpu, 0x0008c2c0U);
@@ -226,10 +270,11 @@
 +                GPU_REG_WR32(pGpu, PCIE_GEN2_PL_LINK_RATE_ADDR, PCIE_GEN2_PL_LINK_RATE_VALUE);
 +                linkCfg = GPU_REG_RD32(pGpu, 0x0008c040U);
 +                linkCfg = (linkCfg & ~0x000C0000U) |
-+                          (((PCIE_GEN2_LINK_SPEED >= 3U) ? 0x1U : 0x2U) << 18);
++                          (CMP_PCIE_MAX_LINK_RATE(targetGen) << 18);
 +                GPU_REG_WR32(pGpu, 0x0008c040U, linkCfg);
 +                NV_PRINTF(LEVEL_ERROR,
-+                          "SEC2_DEBUG: PCIe LINK_CONFIG_0 after MAX_RATE=8G: 0x%08x\n",
++                          "SEC2_DEBUG: PCIe LINK_CONFIG_0 after MAX_RATE=Gen%u: 0x%08x\n",
++                          targetGen,
 +                          GPU_REG_RD32(pGpu, 0x0008c040U));
 +                NV_PRINTF(LEVEL_ERROR,
 +                          "SEC2_DEBUG: PCIe XVE_OVR@8872c=0x%08x; skip mid-boot retrain\n",
@@ -265,7 +310,15 @@
          {
 --- a/src/nvidia/src/kernel/gpu/gsp/arch/turing/kernel_gsp_tu102.c
 +++ b/src/nvidia/src/kernel/gpu/gsp/arch/turing/kernel_gsp_tu102.c
-@@ -611,6 +611,46 @@
+@@ -26,6 +26,7 @@
+  */
+ 
+ #include "gpu/gsp/kernel_gsp.h"
++#include "gpu/gsp/cmp_pcie.h"
+ #include "gpu/gsp/gsp_init_args.h"
+ 
+ #include "gpu/rc/kernel_rc.h"
+@@ -611,6 +612,48 @@
          }
      }
  
@@ -286,7 +339,9 @@
 +                      misc1Late,
 +                      GPU_REG_RD32(pGpu, PCIE_GEN2_PRIV_MISC_1_ADDR_LATE));
 +            {
++                NvU32 targetGenLate = CMP_PCIE_TARGET_GEN(pGpu);
 +                NvU32 cyaLate = GPU_REG_RD32(pGpu, 0x0008c2c0U);
++                NvU32 linkCfgLate;
 +                cyaLate = cyaLate & ~((1U << 2) | (1U << 0));
 +                GPU_REG_WR32(pGpu, 0x0008c2c0U, cyaLate);
 +                NV_PRINTF(LEVEL_ERROR,
@@ -294,13 +349,13 @@
 +                          GPU_REG_RD32(pGpu, 0x0008c2c0U),
 +                          (GPU_REG_RD32(pGpu, 0x0008c2c0U) >> 2) & 1U);
 +                GPU_REG_WR32(pGpu, 0x0008872cU, 0x0000000AU);
-+                NvU32 linkCfgLate = GPU_REG_RD32(pGpu, 0x0008c040U);
++                linkCfgLate = GPU_REG_RD32(pGpu, 0x0008c040U);
 +                linkCfgLate = (linkCfgLate & ~0x000C0000U) |
-+                              (((((GPU_REG_RD32(pGpu, 0x00820250U) & 1U) == 0U)
-+                                 ? 0x1U : 0x2U)) << 18);
++                              (CMP_PCIE_MAX_LINK_RATE(targetGenLate) << 18);
 +                GPU_REG_WR32(pGpu, 0x0008c040U, linkCfgLate);
 +                NV_PRINTF(LEVEL_ERROR,
-+                          "SEC2_DEBUG: PCIe LINK_CONFIG_0 late MAX_RATE=8G: 0x%08x\n",
++                          "SEC2_DEBUG: PCIe LINK_CONFIG_0 late MAX_RATE=Gen%u: 0x%08x\n",
++                          targetGenLate,
 +                          GPU_REG_RD32(pGpu, 0x0008c040U));
 +                NV_PRINTF(LEVEL_ERROR,
 +                          "SEC2_DEBUG: PCIe XVE_OVR late=0x%08x\n",

--- a/driver/patches/pcie-gen2.patch
+++ b/driver/patches/pcie-gen2.patch
@@ -1,7 +1,7 @@
 --- a/src/nvidia/src/kernel/gpu/gsp/kernel_gsp.c
 +++ b/src/nvidia/src/kernel/gpu/gsp/kernel_gsp.c
-@@ -4942,6 +4942,260 @@
-                       devId);
+@@ -4922,6 +4922,262 @@
+                       GPU_REG_RD32(pGpu, 0x00100ce0U));
          }
  
 +
@@ -21,7 +21,8 @@
 +            #define PCIE_GEN2_OPT_GEN3_ADDR         0x00820580U
 +            #define PCIE_GEN2_OPT_MAGIC_ADDR        0x00820520U
 +            #define PCIE_LINK_SPEED_OF(stat)        (((stat) >> 16) & 0xFU)
-+            const NvU32 PCIE_GEN2_LINK_SPEED = 0x00000003U;
++            const NvU32 PCIE_GEN2_LINK_SPEED =
++                (((GPU_REG_RD32(pGpu, 0x00820250U) & 1U) == 0U) ? 3U : 2U);
 +            const NvU32 PCIE_GEN2_PL_LINK_RATE_VALUE = 0x00240036U;
 +
 +            NvU32 capBefore = GPU_REG_RD32(pGpu, PCIE_GEN2_LINK_CAP_ADDR);
@@ -224,7 +225,8 @@
 +                GPU_REG_WR32(pGpu, 0x0008872cU, 0x0000000AU);
 +                GPU_REG_WR32(pGpu, PCIE_GEN2_PL_LINK_RATE_ADDR, PCIE_GEN2_PL_LINK_RATE_VALUE);
 +                linkCfg = GPU_REG_RD32(pGpu, 0x0008c040U);
-+                linkCfg = (linkCfg & ~0x000C0000U) | (0x1U << 18);
++                linkCfg = (linkCfg & ~0x000C0000U) |
++                          (((PCIE_GEN2_LINK_SPEED >= 3U) ? 0x1U : 0x2U) << 18);
 +                GPU_REG_WR32(pGpu, 0x0008c040U, linkCfg);
 +                NV_PRINTF(LEVEL_ERROR,
 +                          "SEC2_DEBUG: PCIe LINK_CONFIG_0 after MAX_RATE=8G: 0x%08x\n",
@@ -263,7 +265,7 @@
          {
 --- a/src/nvidia/src/kernel/gpu/gsp/arch/turing/kernel_gsp_tu102.c
 +++ b/src/nvidia/src/kernel/gpu/gsp/arch/turing/kernel_gsp_tu102.c
-@@ -611,6 +611,44 @@
+@@ -611,6 +611,46 @@
          }
      }
  
@@ -293,7 +295,9 @@
 +                          (GPU_REG_RD32(pGpu, 0x0008c2c0U) >> 2) & 1U);
 +                GPU_REG_WR32(pGpu, 0x0008872cU, 0x0000000AU);
 +                NvU32 linkCfgLate = GPU_REG_RD32(pGpu, 0x0008c040U);
-+                linkCfgLate = (linkCfgLate & ~0x000C0000U) | (0x1U << 18);
++                linkCfgLate = (linkCfgLate & ~0x000C0000U) |
++                              (((((GPU_REG_RD32(pGpu, 0x00820250U) & 1U) == 0U)
++                                 ? 0x1U : 0x2U)) << 18);
 +                GPU_REG_WR32(pGpu, 0x0008c040U, linkCfgLate);
 +                NV_PRINTF(LEVEL_ERROR,
 +                          "SEC2_DEBUG: PCIe LINK_CONFIG_0 late MAX_RATE=8G: 0x%08x\n",


### PR DESCRIPTION
## Summary

1. Fixes an out-of-range MMIO read in the Gen3 retrain that can oops the kernel.
2. Fixes a silent false-positive where a card that fell off the bus is reported as a trained link.
3. Clamps the target speed to the upstream bridge as well as the GPU.
4. Adds `NVreg_CmpPcieGen` so the retrain can be disabled or capped without rebuilding.
5. Renames the fuse result, which was named as the opposite of its value.
6. Moves the target-generation decision into a shared header so the two RM paths cannot drift apart.

All six apply to the retrain added in 80966db and ba82a70.

## Changes

1. **BAR0 mapping reaches the fuse.** `gen3_fused` read `bar0 + 0x820250`, but the
   mapping was `ioremap(pci_resource_start(gpu, 0), 0x90000)`. Every other offset the
   function touches (`0x8c2c0`, `0x8c040`, `0x8872c`, `0x88084`) is inside `0x90000`;
   only the fuse is not, so that read landed on unmapped kernel VA. The mapping is now
   `0x821000`, guarded by a `pci_resource_len()` check.

2. **All-ones LNKSTA is rejected.** Config reads return all ones once a device drops off
   the bus, and `0xFFFF & PCI_EXP_LNKSTA_CLS` is `0xF`, which passed `reached >= target`.
   The loop logged "link trained to Gen15" and returned success for a card that had just
   disappeared, defeating the generational fallback it was meant to trigger.

3. **Upstream bridge caps the target.** Only the GPU's `LINK_CAP` was consulted. The
   bridge's `PCI_EXP_LNKCAP_SLS` is now read and clamped against, so a Gen2 slot no
   longer burns a retrain cycle being asked for Gen3.

4. **`NVreg_CmpPcieGen` module parameter.** `0` disables the retrain, `1`/`2`/`3` cap the
   target at that generation, `-1` (the default) preserves the current automatic
   behavior. A forced value is a cap, never a floor.

5. **Naming.** `gen3_fused` became `gen3_allowed` (`OPT_DISABLE_GEN3_SPEED` is active
   high, so the variable was true when the fuse was clear). `PCIE_GEN2_LINK_SPEED`,
   which now holds Gen3, became `targetGen`. `nv_cmp170hx_retrain_gen2()` became
   `nv_cmp170hx_retrain_pcie()`.

6. **Shared policy header.** `kernel_gsp.c` and `kernel_gsp_tu102.c` each spelled out the
   fuse test and the inverted `MAX_LINK_RATE` encoding, the latter as a nested ternary.
   Both now include `gpu/gsp/cmp_pcie.h`.

## Testing

**Not run on a CMP 170HX.** No hardware was involved in any of the below.

1. All ten patches in `build.sh`'s `PATCH_ORDER` apply to upstream
   open-gpu-kernel-modules 610.57.04 with zero fuzz and zero offset.
2. The generated `nv_cmp170hx_retrain_pcie()` compiles warning free under
   `gcc -Wall -Wextra -Wformat=2` against stubs for the kernel and RM API,
   which covers the printf format strings and the new `pci_resource_len()` cast.
3. `cmp_pcie.h` was compiled and executed with `_Static_assert`s pinning the inverted
   rate table (Gen3 to 1, Gen2 to 2, Gen1 to 3) and runtime checks on the fuse polarity,
   including a case where every bit but bit 0 is set.
4. Trees were built from the pre-change patches and from these patches and the generated
   sources diffed. The RM-side register writes are byte-for-byte identical; only log text
   changed, because `MAX_RATE=8G` was wrong whenever the fuse forced Gen2.

## Notes

1. Items 1 and 2 under Changes are the ones worth validating on real hardware first.
   Item 1 is a fault, item 2 hides a card that has gone away.
2. Polling is still 20 x 100 ms per generation, so a full three-generation fallback still
   costs about six seconds inside `nv_start_device()` while `nvl->ldata_lock` is held.
   Deliberately left alone in this PR.
3. The late path in `kernel_gsp_tu102.c` still has no `PL_LINK_RATE` write, unlike the
   mid-boot path. Making them identical would change hardware behavior, which does not
   belong in a refactor and needs a card to validate.
4. Gen4 is not attempted. The Gen4 fuse bit and its `MAX_LINK_RATE` encoding are both
   unknown; that is separate work.
5. `nv.c` repeats the `MAX_LINK_RATE` table because `kernel-open/` and `src/nvidia/` are
   separate build units and cannot share the header. Both copies carry the same comment.
6. The comments removed in 0ec6650 were not restored. Only the lines touched here carry
   new comments.